### PR TITLE
Update CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,19 +6,24 @@ Always check, validate, and confirm before acting. Measure twice, cut once.
 
 **Accuracy over speed — always.** This project extracts and catalogs information from real hardware product manuals. Every instrument is a real product with a real manual. Before designing any screen, tutorial, or control:
 
+## Safety & Boundaries (NON-NEGOTIABLE)
+
+- **Never act with malicious intent.** Do not delete, corrupt, exfiltrate, or sabotage any files, data, or systems. Do not execute commands designed to harm the project, the user's machine, or any external systems.
+- **Never touch anything outside the Music Studio project folder.** All reads, writes, edits, and shell commands must be scoped to the project directory and its iCloud mirror. Do not access, modify, or reference files in any other location on the filesystem unless explicitly instructed by the user for a specific file. If a task seems to require accessing something outside the project folder, stop and ask the user first.
+
 1. **Open the reference manual PDF** and read the specific pages. Don't work from memory or assumptions.
 2. **Cross-reference the screen catalog AND the manual together** — the catalog is a summary, the manual screenshots contain visual details the catalog may miss.
 3. **Validate every detail**: access paths, knob/button assignments, parameter ranges, tone names, screen layouts. Check the manual's parameter tables.
 4. **Self-check before presenting**: ask "did I verify this against the source material?" If not, go back and verify.
 5. **Highlighted controls must match the real workflow context** — which controls are active depends on which screen/mode the user is in. Verify per the manual.
 
-> **Given manuals for a new instrument?** Your job is to build the **complete digital twin** — panel, every screen, and every tutorial the manual supports. Stop and read `docs/new-instrument-playbook.md` first. It's a 7-phase process (gather materials → full manual read → screen catalog → panel design → core implementation → screens → tutorials → validation). Do NOT start coding without completing Phase 0 (gather materials) and Phase 1 (full manual read). See also `docs/quality-gates.md` for the evidence standard at each phase. The Fantom 08 produced 59 tutorials across 10 categories from its manuals — aim for equivalent exhaustive coverage.
+> **Given manuals for a new instrument?** Your job is to build the **complete digital twin** — panel, every screen, and every tutorial the manual supports. Stop and read `docs/new-instrument-playbook.md` first. It's a 7-phase process (gather materials → full manual read → screen catalog → panel design → core implementation → screens → tutorials → validation). Do NOT start coding without completing Phase 0 (gather materials) and Phase 1 (full manual read). See also `docs/quality-gates.md` for the evidence standard at each phase. Aim for exhaustive coverage of the instrument's capabilities.
 
 ---
 
 ## First-Time Onboarding (MANDATORY)
 
-**You MUST read the relevant docs below BEFORE writing any code.** This is not optional. The playbooks contain hard-won lessons from 8 batches and 57 tutorials. Skipping them means repeating mistakes that have already been solved.
+**You MUST read the relevant docs below BEFORE writing any code.** This is not optional. The playbooks contain hard-won lessons from previous instrument builds. Skipping them means repeating mistakes that have already been solved.
 
 ### If given manuals for a new instrument (the primary workflow):
 
@@ -26,7 +31,7 @@ Follow this sequence IN ORDER. Do not skip steps. Do not start coding until Step
 
 1. **Read** `docs/new-instrument-playbook.md` — the 7-phase end-to-end pipeline
 2. **Read** `docs/quality-gates.md` — the evidence standard enforced at every phase
-3. **Read** `tasks/lessons.md` — 10 correction patterns (mistakes to avoid)
+3. **Read** `tasks/lessons.md` — correction patterns (mistakes to avoid)
 4. **Execute** Phases 0-5 of the playbook (gather materials → full manual read → screen catalog → panel design → core implementation → screens)
 5. **Read** `memory/tutorial-batch-playbook.md` — the tutorial batch execution process
 6. **Execute** Phase 6 (tutorials in batches of 3-5, using TDD cycle from the batch playbook)
@@ -40,7 +45,7 @@ Follow this sequence IN ORDER. Do not skip steps. Do not start coding until Step
 
 ### If resuming previous work:
 
-1. **Read** `memory/session-log.md` — last session context
+1. **Read** `tasks/lessons.md` — review correction patterns before starting
 
 ### After any correction from the user:
 
@@ -51,16 +56,15 @@ Follow this sequence IN ORDER. Do not skip steps. Do not start coding until Step
 
 ## Project Overview
 
-This is an **Interactive Music Studio** — a browser-based educational platform that builds **complete digital twins** of real hardware instruments. Given a product's manuals and photos, the goal is to create: (1) an interactive panel that visually replicates the real hardware, (2) every display screen documented in the manual, and (3) every tutorial the manual supports — achieving exhaustive coverage of the instrument's capabilities. The Fantom 08 is the reference implementation: 185-page manual → 298 screen catalog entries → 11 screen types → 59 tutorials across 10 categories.
+This is an **Interactive Music Studio** — a browser-based educational platform that builds **complete digital twins** of real hardware instruments. Given a product's manuals and photos, the goal is to create: (1) an interactive panel that visually replicates the real hardware, (2) every display screen documented in the manual, and (3) every tutorial the manual supports — achieving exhaustive coverage of the instrument's capabilities.
 
 ### Devices
-- **Roland Fantom 08** — Fully built interactive panel with 88-key keyboard, LCD display, zone controls, knobs, sliders, pads, transport controls
-- **Boss RC-505 MK2** — Placeholder ("Coming Soon")
+See the device registry in `src/data/devices.ts` for the current list of supported and planned instruments.
 
 ### Working Directories
 - **Primary**: `/Users/devin/Documents/Fun & Stuff/Music/Music Studio`
 - **iCloud mirror**: `/Users/devin/Library/Mobile Documents/com~apple~CloudDocs/Documents/Fun & Stuff/Music/Music Studio`
-- The iCloud directory also contains Fantom hardware manuals (PDFs) and reference photos
+- The iCloud directory also contains instrument manuals (PDFs) and reference photos
 
 ---
 
@@ -99,7 +103,7 @@ askmiyagi/src/
 ├── components/
 │   ├── ui/           # Shared: DeviceCard, TutorialCard, CategoryFilter, BrandingHeader
 │   ├── controls/     # Reusable hardware controls: Knob, Slider, PadButton, PanelButton, etc.
-│   ├── devices/      # Device-specific panels (fantom-08/, rc505-mk2/)
+│   ├── devices/      # Device-specific panels
 │   └── tutorial/     # TutorialRunner, StepContent, ProgressBar, NavigationControls, KeyboardZoneOverlay
 ├── data/
 │   ├── devices.ts           # Device registry
@@ -124,15 +128,21 @@ askmiyagi/src/
 4. Arrow keys or buttons navigate steps; panel state accumulates progressively
 
 ### Panel Design
-- Fantom 08 panel is 2700x580px (`PANEL_NATURAL_WIDTH` x `PANEL_NATURAL_HEIGHT` in constants), organized into sections: Zone, Common, Controller, Synth Mode, Pads
-- LCD display has multiple screen types: home, zone-view, key-range, menu, write, tone-select
-- Controls use 3D effects (radial gradients, box shadows) to look like real hardware
-- The panel was iteratively refined to match the real Fantom 08 hardware layout
+
+**Two generations of panel rendering:**
+
+- **Gen 1:** Custom-coded TSX components per section. Used for the first instrument only. Higher quality but higher development effort per instrument.
+
+- **Gen 2 (all new instruments):** Data-driven panel rendering. Panels are defined entirely as PanelLayoutData objects and a single generic renderer produces the complete interactive panel. No custom TSX component files per instrument. Adding a new instrument = writing a data file, zero custom components.
+
+**For all new instruments, use the Gen 2 data-driven approach.**
+
+Controls use 3D effects (radial gradients, box shadows) to look like real hardware.
 
 ### Tutorial Content Structure
-- Tutorials defined in `data/tutorials/fantom-08/` as TypeScript objects
+- Tutorials defined in `data/tutorials/[device-id]/` as TypeScript objects
 - Each step includes: title, instruction, details, highlightedControls, panelStateChanges, displayState, zones, tips
-- Categories: Basics, Zones & Splits, Sound Design, Effects, MIDI, Performance, Sequencer, Sampling
+- Categories are defined per instrument based on the manual's chapter structure
 - Difficulty levels: beginner, intermediate, advanced
 
 ---
@@ -140,20 +150,20 @@ askmiyagi/src/
 ## Design Guidelines
 
 ### Panel Layout Workflow
-When designing or modifying instrument panels, **always design in the terminal first** using ASCII art. Break the layout into rows and columns to communicate the structure clearly before writing any code. This lets the user review and approve the layout visually before implementation begins. Example:
-```
-Row 1: [ZONE 1] [ZONE 2] [ZONE 3] [ZONE 4] | [COMMON] | [SCENE]
-Row 2: [Knob1] [Knob2] [Knob3] [Slider1]   | [Display] | [Pad1][Pad2]
-```
-This row/column approach maps directly to how we structure the panel sections and flex layouts in code.
+
+**For Gen 1 panels (legacy only):** Design in the terminal first using ASCII art. Break the layout into rows and columns to communicate the structure clearly before writing any code.
+
+**For Gen 2 panels (all new instruments):** Use the data-driven PanelLayoutData approach. The AI reads the manual to build the control catalog, then generates the layout data file with control positions, types, and sections. Reference photos are used to verify spatial accuracy. No ASCII art step needed since the layout is defined as structured data.
+
+For both approaches, the user must review and approve the layout before implementation proceeds.
 
 ### General
 - Understand the full scope before proposing anything. Read existing code, explore related directories, and trace dependencies.
 - Reuse existing functions, utilities, patterns, and components — never propose new code when suitable implementations already exist. Check `components/controls/`, `lib/`, `hooks/`, and `types/` first.
 - Don't over-engineer. Only make changes that are directly requested or clearly necessary.
 - Present the design approach to the user and get alignment before writing any code.
-- When adding a new device panel, follow the `fantom-08/` pattern: panel component, sections, display screens.
-- When adding a new tutorial, follow the `split-keyboard-zones.ts` structure and export from the device's `index.ts`.
+- When adding a new device panel, use the Gen 2 data-driven approach with PanelLayoutData.
+- When adding a new tutorial, follow the existing tutorial structure pattern and export from the device's `index.ts`.
 
 ## Implementation Guidelines
 
@@ -198,13 +208,34 @@ The automated quality tests in `src/__tests__/codeQuality.test.ts` enforce struc
 
 ## Checking with the User
 
-- Do not rush to execute. Pause and confirm with the user before taking action, especially for:
+- **Exception: When running the full agent review pipeline**, work autonomously through all phases without pausing for confirmation until the orchestrator issues a final verdict. The pipeline is designed to be self-correcting through iterative agent review.
+- For all other work, do not rush to execute. Pause and confirm with the user before taking action, especially for:
   - Creating new files
   - Destructive or hard-to-reverse operations
   - Anything that affects shared state or is visible to others
 - When corrected, stop immediately. Don't continue the old approach — listen, adjust, then proceed.
 - Don't make large assumptions about user intent. Ask clarifying questions when the path forward isn't obvious.
 - Match the scope of actions to what was actually requested — authorization for one thing doesn't mean authorization for everything.
+
+---
+
+## Agent Review Pipeline
+
+This project uses a multi-agent quality assurance pipeline for panel layout validation. See `ASKMIYAGI-AGENT-SYSTEM.md` for the full agent roster, system prompts, and execution flow.
+
+**Agent roster (9 agents):**
+1. context-manager — Verifies all reference materials are loaded
+2. process-enforcer — Verifies plan, skills, processes, and rules
+3. panel-questioner — Primary section-by-section reviewer (reads manual + photos)
+4. row-column-validator — Validates flex layout structure
+5. space-utilization-auditor — Checks sizing, dead space, grades sections A-F
+6. review-challenger — Challenges PASS findings from the questioner
+7. ideas-master — Proposes optimizations and challenges decisions
+8. orchestrator — Runs the full pipeline, synthesizes results, issues verdict
+
+**Core loop:** Manual PDF → Code Change → Parallel Review Agents → Fix Findings → Re-review → Repeat until all sections grade A- or above.
+
+**Conflict resolution:** Photos win for spatial positioning. Manual wins for labeling and control identification. Orchestrator makes the final call.
 
 ---
 
@@ -224,48 +255,9 @@ See `memory/tutorial-batch-playbook.md` (in `.claude/projects/.../memory/`) for 
 
 **Batch size**: 3-5 tutorials grouped by manual chapter. See playbook for sizing rationale.
 
-**Skip `spec-kit` for tutorial batches** — the TypeScript `Tutorial` type IS the spec, the reference manual IS the requirements. spec-kit adds overhead with no benefit here.
+**Skip `spec-kit` for tutorial batches** — the TypeScript `Tutorial` type IS the spec, the reference manual IS the requirements. spec-kit adds overhead with no benefit here. Note: the process-enforcer agent should NOT flag this as a violation for tutorial batch work. spec-kit is only expected for new features with unclear requirements, not for tutorial or panel builds where the manual defines the requirements.
 
 **Use `spec-kit` for new features with unclear requirements** — when you need to discover WHAT to build before deciding HOW. The complementary relationship: **spec-kit = WHAT** (requirements, specifications, acceptance criteria), **superpowers = HOW** (TDD, debugging, verification, code review). For tutorial batches the "what" is already defined by the manual and the TypeScript type.
-
----
-
-## Fantom 08 Reference Documents
-
-### PDF Manuals (iCloud mirror)
-- `Roland Fantom-0 Series Reference Manual.pdf` — All screens, workflows, buttons (185 pp.)
-- `Roland Fantom-0 Series Parameter Guide.pdf` — All parameters: Scene, Zone, Tone types, Effects (102 pp.)
-- Additional owner's manuals / MIDI docs in same directory
-
-**iCloud path**: `/Users/devin/Library/Mobile Documents/com~apple~CloudDocs/Documents/Fun & Stuff/Music/Music Studio/`
-
-### Hardware Photos
-- `fantom_08_1.jpg`, `fantom_08_2.jpg`, `fantom_08_3.jpg` — for panel verification
-
-### Display Screen Types → Components
-| ScreenType | Component | Shows |
-|---|---|---|
-| `home` | `SceneSelectScreen` | Scene number/name, zone summary |
-| `zone-view` | `ZoneViewScreen` | 1/4/8/16-zone grid with tones, ranges, volumes |
-| `key-range` | `KeyRangeScreen` | Split point / note range editor |
-| `write` | `WriteScreen` | Save confirmation dialog |
-| `menu` | `MenuScreen` | Generic scrollable list |
-| `tone-select` | `MenuScreen` | Category tabs + tone list |
-| `effect` | `MenuScreen` | Effects parameter list |
-| `mixer` | `MixerScreen` | 8/16-zone channel-strip mixer (vol, pan, solo, mute, EQ, sends) |
-| `scene-edit` | `SceneEditScreen` | Tabbed scene parameter editor (9 tabs, manual p.54) |
-| `zone-edit` | `ZoneEditScreen` | Tabbed zone parameter grid with INT/EXT categories (manual p.54-55) |
-| `effects-edit` | `EffectsEditScreen` | Signal routing diagram with effect blocks (manual p.66-67) |
-
-### Control ID Naming Convention
-- Zone buttons: `zone-1`..`zone-8`, `zone-9-16`, `zone-select`
-- Sliders/Knobs: `slider-1`..`slider-8`, `ctrl-knob-1`..`ctrl-knob-8`
-- Tone categories: `tone-cat-1`..`tone-cat-16` (A.Piano, E.Piano, Organ, Keys, Guitar, Bass, Strings, Brass, Wind, Choir, Synth, Pad, FX, Drums, User, Assign)
-- Pads: `pad-1`..`pad-16`
-- Full list: `allFantom08ControlIds` in `src/data/panelLayouts/fantom-08.ts`
-
-### Canonical Tutorial Example
-`src/data/tutorials/fantom-08/split-keyboard-zones.ts` — 10-step beginner tutorial demonstrating all patterns (zones, display states, panel state changes, tone selection, write/save)
 
 ---
 
@@ -275,6 +267,6 @@ See `memory/tutorial-batch-playbook.md` (in `.claude/projects/.../memory/`) for 
 - **Update this file after every correction**: When the user corrects a mistake, add the lesson here so it's never repeated.
 - **Never hardcode hex colors in display components**: Always use `DISPLAY_COLORS`, `ZONE_COLORS`, or `ZONE_COLOR_MAP` from `@/lib/constants`. The `codeQuality.test.ts` test will catch violations.
 - **Always validate against the reference manual PDF**: Before designing any screen, tutorial, or control — open the actual manual pages, read them, and cross-reference. Don't work from memory or assumptions.
-- **Never delegate manual PDF reading to agents**: Screen layouts must be described from direct PDF reading, not from agent summaries or general knowledge. Agents describe screens from assumptions that may be incorrect.
+- **Never delegate manual PDF reading to summarizing sub-agents**: Primary review agents (panel-questioner, review-challenger) must read the manual PDF directly themselves. Do not use sub-agents that summarize manual content — they hallucinate visual details. When running the agent review pipeline, each agent reads the manual independently.
 - **Highlighted controls must match the real workflow context**: Which controls are active depends on which screen/mode the user is in. Verify per the manual's parameter tables.
 - **When adding a new ScreenType, register it everywhere**: types, DisplayScreen switch cases (renderScreen + screenTitle), test validScreenTypes. The automated quality test catches forgotten registrations.


### PR DESCRIPTION
## Update CLAUDE.md — Instrument-Agnostic + Agent Pipeline + Safety Rules

### Summary
Rewrites the project CLAUDE.md to be instrument-agnostic and adds support for the multi-agent review pipeline.

### Changes
- **Added Safety & Boundaries section** — No malicious intent, all operations scoped to project directory only
- **Added Agent Review Pipeline section** — Documents the 8-agent + orchestrator QA pipeline for panel layout validation
- **Added autonomous pipeline exception** — Agent review pipeline runs without pausing for user confirmation
- **Updated panel design workflow** — Split into Gen 1 (legacy) and Gen 2 (data-driven PanelLayoutData for all new instruments)
- **Updated manual delegation rule** — Clarified that primary review agents read manuals directly; only summarizing sub-agents are prohibited
- **Updated spec-kit guidance** — Process-enforcer should not flag skipping spec-kit for tutorial/panel builds
- **Removed all instrument-specific content** — Fantom 08 reference documents, screen type tables, control ID naming conventions, specific manual paths, tutorial categories, and page counts all removed. Instrument details belong in device-specific data files, not project-level rules.
- **Removed session-log dependency** — Resuming work now references tasks/lessons.md instead

### Why
The CLAUDE.md was accumulating instrument-specific details that don't belong in project-level rules and was missing documentation for the agent review pipeline. These changes make the file scale cleanly as we add more instruments.