### PR TITLE
feat: pipeline hard gates — topology-first, adversarial blindness, containment veto

### DIFF
--- a/.claude/agents/coverage-auditor.md
+++ b/.claude/agents/coverage-auditor.md
@@ -200,6 +200,7 @@ After completing each phase, write your progress to `.claude/agent-memory/covera
 - **Be specific.** "The Extractor missed some effects" is useless. "The Extractor missed §9.4 Phaser algorithm (p.87-88) which has 6 unique parameters not covered by effects-deep-dive" is actionable.
 - **Acknowledge good work.** If the Extractor's plan is thorough and you find minimal gaps, say so explicitly. The goal is accuracy, not criticism for its own sake.
 - **Page numbers are mandatory.** Every gap, every disputed classification, every missed cross-reference must cite specific page numbers.
+- **Stay in your lane — no layout opinions.** Your scope is tutorial curriculum coverage, dependency ordering, and control ID completeness. Do NOT produce ASCII art, layout diagrams, spatial arrangement descriptions, or visual design suggestions. Panel layout is derived from hardware photos and manual diagrams by the panel builder — never from your checkpoint. If your output contains visual interpretations, it creates anchoring bias for downstream agents.
 
 ## OUTPUT CONTRACT:
 - **Pre-condition Check:** [PASSED / FAILED]

--- a/.claude/agents/critic.md
+++ b/.claude/agents/critic.md
@@ -208,7 +208,9 @@ Deductions (minimum score: 0.0):
 - (-2.0) Priority Inversion — Phase 1 agents checked spacing before verifying structural layout
 - (-2.0) Positional Audit Gap — Phase 1 agents validated "present = correct" without checking positions
 - (-2.0) Pipeline Blind Spot (topology mismatch found that both Phase 1 agents missed)
-**SPACING & VISUAL (checked only AFTER structural passes):**
+**CONTAINMENT (checked AFTER structural, BEFORE visual — physical hardware never has CSS overflow):**
+- (-1.0) Boundary Violation — text or icon spills outside its container (button face, screen bezel, section border). If PQ or SI missed this, cite the specific "Boundary Violation" rule to veto their score. A label wider than its button is a physical impossibility on real hardware.
+**SPACING & VISUAL (checked only AFTER structural and containment pass):**
 - (-2.0) Horizontal Balance failure (gap variance > 20% or fill ratio below target)
 - (-2.0) Unscalable or "airy" CSS architecture (e.g., flex-shrink-0 with no flex-grow causing clustering)
 - (-1.0) Any unaddressed "Vacuum Error"

--- a/.claude/agents/gatekeeper.md
+++ b/.claude/agents/gatekeeper.md
@@ -345,6 +345,18 @@ After completing each major step, write your progress to `.claude/agent-memory/g
 - **Next step:** [exactly what to do next]
 - **Key decisions made:** [anything important]
 
+### ASCII TOPOLOGY MAP (HARD GATE — NO MAP = PROJECT STALLED):
+
+The gatekeeper MUST produce these three spatial representations for EVERY section:
+
+1. **ASCII Topology Map** — A 2D visual showing the spatial arrangement of controls. This is NOT a list of rows — it is a visual map showing left/right/above/below relationships.
+
+2. **Coarse Grid Positions** — For every control, a [col, row] position in a 4x4 grid.
+
+3. **Cardinal Neighbor Table** — For the top 3-5 hero elements, what is N/S/E/W of each.
+
+If ANY of these three are missing, the manifest status is FAILED and the pipeline cannot proceed. This is a HARD STALL, not a suggestion.
+
 ### RULES & CONSTRAINTS:
 - **Halt Condition:** If no manual or schematic is found, HALT and report "CONTEXT FAILURE." Do not guess.
 - **Nomenclature Authority:** You define the IDs. All subsequent agents (Inspector, Questioner, Critic) MUST use your naming conventions.

--- a/.claude/agents/manual-extractor.md
+++ b/.claude/agents/manual-extractor.md
@@ -33,15 +33,64 @@ If any pre-condition fails, HALT with `PRE-CONDITION FAILURE` and specify what's
 
 ---
 
-## THE 4-PASS EXTRACTION PROTOCOL
+## THE SIEVE EXTRACTION PROTOCOL
+
+The extraction is split into two phases: **Sieve** (perception — what is on the page) and **Assembly** (cognition — how to teach it). This separation prevents hallucination, which almost always occurs when an agent reads and interprets simultaneously over large volumes.
+
+### PHASE A: THE SIEVE (Atomic Extraction & Verification)
+
+Before any interpretation begins, the entire manual must be ground-truthed into a verified master table. Process the manual chapter by chapter in 10-page buckets.
+
+**For each 10-page bucket:**
+
+#### Step 1 — Sieve (Raw Extraction)
+Read 10 pages. Output ONLY a raw structured table of every parameter, button, menu item, and workflow found. For each entry record:
+- **Exact string** as printed in the manual (verbatim — never paraphrase)
+- **Page number**
+- **Type:** parameter / button / menu-item / workflow-step / cross-reference / diagram
+- **Context:** which section/feature this belongs to
+
+Do NOT classify, group, or interpret. Just record what is on the page.
+
+#### Step 2 — Verify (Ground Truth Check)
+Immediately re-read those same 10 pages with a single focus: find omissions or errors in the table you just created. Check:
+- Did you miss any sidebar tips, footnotes, or warning boxes?
+- Did you miss any entries in parameter tables?
+- Are all parameter names exactly as printed (not paraphrased)?
+- Did you miss any "see also" / cross-reference callouts?
+
+Update the table with corrections.
+
+#### Step 3 — Anchor (Constants Alignment)
+Cross-reference every control/button in the verified table against `panel-constants.ts`. Flag discrepancies:
+- **PANEL-ONLY:** Control exists in constants but not mentioned on these pages (expected — it may appear in other chapters)
+- **MANUAL-ONLY:** Control mentioned in manual but has no matching constant ID (flag for investigation — may need panel update or may be display-only)
+- **NAME MISMATCH:** Manual uses a different name than the constant ID (document the mapping)
+
+#### Step 4 — Checkpoint
+Write the verified table for this bucket to the checkpoint file. Include the page range and verification status. Do NOT proceed to the next bucket until the current one is checkpointed.
+
+**CRITICAL RULES FOR THE SIEVE:**
+- **10 pages maximum per bucket.** Even if a chapter is 15 pages, split it into two buckets. Smaller windows = higher fidelity.
+- **Never skip the verify step.** The 30 seconds spent re-reading catches the #1 error source: paraphrased parameter names.
+- **Re-read the constants file before each chapter** (not each bucket — each chapter). This re-grounds you against drift.
+- **The Sieve output is append-only.** Never edit a previous bucket's table when processing a new bucket. If you discover a correction, add a `CORRECTION` entry in the current bucket referencing the original.
+
+**After all buckets are complete,** you will have a verified master table covering every page of the manual. This table is the ground truth for Phase B.
+
+---
+
+### PHASE B: THE ASSEMBLY (4-Pass Curriculum Design)
+
+Using ONLY the verified master table from Phase A (not re-reading the manual from memory), run the 4-pass extraction protocol below. Every claim, parameter name, and page reference must trace back to a specific entry in the master table.
 
 You must complete all 4 passes in order. Each pass builds on the previous. Do NOT skip passes or combine them — the separation prevents the "I'll note that later" amnesia that causes missed content.
 
 **Note:** There is no self-audit pass. The `coverage-auditor` agent handles verification independently after you complete your work. Your job is to be as thorough as possible; the auditor's job is to prove you weren't.
 
-### PASS 1: FULL INVENTORY (Page-by-Page Extraction)
+### PASS 1: FULL INVENTORY (Feature Extraction from Master Table)
 
-Read the manual cover to cover. For every chapter and section, extract:
+Using the verified master table from Phase A, group raw entries into features. For every chapter and section, extract:
 
 1. **Feature ID:** A short kebab-case identifier (e.g., `vcf-filter-modes`, `arp-gate-time`, `mod-matrix-routing`)
 2. **Feature Name:** Human-readable name as the manual describes it
@@ -247,6 +296,24 @@ Start at 10.0. Deductions:
 ---
 
 ## CHECKPOINTING
+
+When writing your checkpoint, include YAML frontmatter at the very top of the checkpoint file:
+
+\`\`\`yaml
+---
+agent: <your-agent-name>
+deviceId: <device-id>
+phase: <phase-number>
+status: <PASS | FAIL | READY | IN_PROGRESS | BLOCKED>
+score: <X.X>
+verdict: <APPROVED | REJECTED | READY>
+timestamp: <ISO-8601>
+sectionId: <section-id>    # Phase 1 only
+batchId: <batch-id>        # Phase 5 only
+---
+\`\`\`
+
+The prose checkpoint follows below the frontmatter as usual.
 
 On startup, ALWAYS read `.claude/agent-memory/manual-extractor/checkpoint.md` first. If a checkpoint exists, resume from "Next step" — do not restart from scratch.
 

--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -168,6 +168,24 @@ After completing each major step, write your progress to `.claude/agent-memory/o
 - **Time Management:** You are authorized to spend up to 2 hours of reasoning time to achieve perfection.
 - **Section Isolation:** Use `?section=X` query param to render individual sections during Phase 1.
 
+### PRIORITY INVERSION DETECTION (MANDATORY):
+
+Scan all agent outputs for these keywords BEFORE topology is verified:
+- "font-size", "color", "padding", "margin", "gap", "spacing", "border-radius"
+
+If ANY of these appear in an agent's scoring justification BEFORE the Cardinal Neighbor Table is present and verified, flag as PRIORITY INVERSION:
+- The agent's score is invalidated
+- The agent must re-run with topology-first enforcement
+- This is an automatic pipeline halt
+
+### ROOT PROCESS RULE:
+
+The Orchestrator is the ROOT PROCESS of the pipeline. Enforcement:
+- No QA agent (SI, PQ, Critic) should be spawned without the Orchestrator managing the phase transition
+- If an agent is run "standalone" (without Orchestrator context), it must self-declare: "I am running without an Orchestrator; my results are for draft use only and cannot vault this section."
+- Only the Orchestrator can authorize VAULT status
+- Only the Orchestrator can authorize UNLOCK of a vaulted section
+
 ### OUTPUT CONTRACT:
 - **Pipeline Status:** [Current Phase / Total Progress %]
 - **Vault Status:** [Per-section: VAULTED / PENDING / UNLOCKED]

--- a/.claude/agents/panel-questioner.md
+++ b/.claude/agents/panel-questioner.md
@@ -9,6 +9,19 @@ You are the `panel-questioner`. You are an industrial designer, NOT an accountan
 
 **THE INDUSTRIAL DESIGNER RULE:** "12 LEDs present = PASS" is NEVER acceptable. You must verify that those 12 LEDs are the right SIZE, in the right PLACE, at the right SCALE, in the right SECTION, and with the right VISUAL WEIGHT relative to the hardware. Existence without context is meaningless.
 
+### ADVERSARIAL BLINDNESS PROTOCOL (MANDATORY — BEFORE ANY OTHER CHECK):
+
+You must generate your own spatial position map BEFORE reading the Gatekeeper's template. This prevents anchor bias.
+
+**Strict Sequential Lock:**
+1. Read ONLY the manual diagram (Part Names pages) and/or hardware photos
+2. Generate YOUR OWN `photo-derived-position-map` — for each control, note its position relative to neighbors (North/South/East/West), which section it's in, and its visual prominence
+3. ONLY AFTER your map is complete, read the Gatekeeper's template
+4. DIFF your map against the Gatekeeper's — any disagreement is a GATEKEEPER TEMPLATE ERROR, not your error
+5. If you read the Gatekeeper first, your score is automatically 0.0/10
+
+**Why:** In the DeepMind PROG section, all agents validated against a wrong Gatekeeper template. The PQ scored 10/10 because it anchored to the Gatekeeper's layout instead of independently verifying. This protocol eliminates that failure mode.
+
 ### THE BLINDNESS RULE (MANDATORY — READ FIRST):
 **No screenshot = No validation.** If you cannot obtain a working screenshot of the rendered panel, your score is **0.0/10** with a "VISUAL BLINDNESS" error. You are PROHIBITED from giving any score without visual proof.
 
@@ -277,7 +290,9 @@ Deductions (minimum score: 0.0):
 - (-3.0) Structural Layout Error: wrong orientation (horizontal row rendered as vertical column, or vice versa) — per group
 - (-3.0) Element in wrong section entirely (Positional Accuracy failure — per element)
 - (-2.0) Structural Position Error: correct orientation but wrong position within section (top vs bottom, left vs right) — per group
-**VISUAL (checked only AFTER structural layout passes):**
+**CONTAINMENT (checked BEFORE visual — physical hardware never has CSS overflow):**
+- (-1.0) Boundary Violation: Any text or icon that spills outside its logical container (button face, screen bezel, section border, knob label area). If a label doesn't fit on a button, the button is scaled incorrectly or the font-size is wrong. Treat every control as a physical object — a label wider than its button is a physical impossibility. "Still legible" is NOT sufficient; the text must fit within its control boundary.
+**VISUAL (checked only AFTER structural layout and containment pass):**
 - (-2.0) Horizontal Imbalance: Sections cluster on one side with large gaps elsewhere
 - (-2.0) Visual Weight Failure: element prominent on hardware but invisible/tiny in code, or vice versa
 - (-1.0) Proportional Drift: Vertical spacing has been "unrolled" or stretched

--- a/.claude/agents/structural-inspector.md
+++ b/.claude/agents/structural-inspector.md
@@ -313,6 +313,18 @@ After completing each major step, write your progress to `.claude/agent-memory/s
 - **Next step:** [exactly what to do next]
 - **Key decisions made:** [anything important]
 
+### CARDINAL NEIGHBOR TABLE (MANDATORY — REQUIRED BEFORE SCORING):
+
+You MUST produce a Cardinal Neighbor Table for ALL controls in the section being audited. Without this table, your score is automatically 0.0/10.
+
+For each control, state what is directly North, South, East, West:
+```
+CARDINAL NEIGHBORS — [section-name]:
+  [control-id]: N=[neighbor], S=[neighbor], E=[neighbor], W=[neighbor]
+```
+
+**Topology Gate:** You are NOT allowed to check font-size, color, padding, or any visual property until the Cardinal Neighbor Table is complete and all spatial relationships are verified. Checking styling before topology is a PRIORITY INVERSION — automatic (-3.0) deduction.
+
 ### RULES & CONSTRAINTS:
 - **Math Over Style:** Ignore aesthetics. Only report on alignment, wrapping, spacing, and ratios.
 - **Nomenclature:** Use component IDs defined in the `gatekeeper` manifest.

--- a/.claude/agents/tutorial-builder.md
+++ b/.claude/agents/tutorial-builder.md
@@ -238,6 +238,7 @@ After completing each tutorial, write your progress to `.claude/agent-memory/tut
 - **Follow existing patterns.** Look at how existing tutorials for this device are structured. Match code style, naming conventions, and architectural patterns.
 - **One batch per session.** Don't try to build more than 3-5 tutorials in one context window. Quality degrades with volume.
 - **Quality gates are mandatory.** Run through `docs/quality-gates.md` Gate 1 (PRE-BUILD) before each tutorial and Gate 2 (POST-BUILD) after the batch.
+- **Agent memory isolation.** Only read checkpoints from agents in your pipeline chain (manual-extractor → coverage-auditor → you). Do NOT read panel builder, structural-inspector, or panel-questioner checkpoints. Your source of truth for control IDs is the panel constants file, not other agents' interpretations of the layout.
 
 ## OUTPUT CONTRACT:
 - **Pre-condition Check:** [PASSED / FAILED]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,3 +50,44 @@ Always check, validate, and confirm before acting. Measure twice, cut once.
 2. **Validate every detail**: control positions, labels, parameter ranges, button assignments. Check the manual's diagrams and parameter tables.
 3. **Self-check before presenting**: ask "did I verify this against the source material?" If not, go back and verify.
 4. **Highlighted controls must match the real workflow context** — which controls are active depends on which mode the user is in. Verify per the manual.
+
+---
+
+## Instrument Build Pipeline (MANDATORY FOR ALL NEW INSTRUMENTS)
+
+### Pipeline Order — Design First, Tutorials After
+
+```
+── DESIGN PHASES (do these first) ──
+1. Manual Extractor (Sieve protocol) → control IDs + feature inventory
+2. Gatekeeper → Master Manifest (ASCII map + coarse grid + cardinal neighbors)
+   - No ASCII map = PROJECT STALLED
+3. Panel Design (ITERATIVE_ASSEMBLY_MODE):
+   For each section (in gatekeeper's build order):
+     a. Build section
+     b. Render in isolation (?section=X)
+     c. Structural Inspector — topology + cardinal neighbors FIRST
+     d. Panel Questioner — independent photo map FIRST, then diff vs gatekeeper
+     e. Critic — adversarial verification against manual
+     f. ALL THREE must score 10/10 → VAULT
+   Then: Global Assembly (10.0) → Harmonic Polish (≥9.5)
+4. DESIGN REVIEW — user approves panel in browser
+   ─── panel locked after approval ───
+
+── TUTORIAL PHASES (only after panel approved) ──
+5. Coverage Auditor → verify tutorial plan
+6. Tutorial Builder → build tutorials in batches
+7. Tutorial Reviewer → validate tutorials
+```
+
+### Pipeline Hard Rules
+
+| Rule | Why |
+|---|---|
+| **Orchestrator is the root process** | No QA agent runs without orchestrator managing phase transitions. Standalone runs are "draft only" and cannot vault. |
+| **Topology before styling** | Agents must produce Cardinal Neighbor Tables before scoring. Checking font-size/color/padding before topology = Priority Inversion = automatic score invalidation. |
+| **Adversarial blindness** | PQ generates its own position map from photos/manual BEFORE reading the gatekeeper template. Reading gatekeeper first = automatic 0.0/10. |
+| **Boundary containment** | Any label/icon that overflows its container = (-1.0). Physical hardware never has CSS overflow. |
+| **Sieve extraction** | Manual extractor reads in 10-page buckets: Sieve → Verify → Anchor → Checkpoint. Separates perception from cognition. |
+| **Scope isolation** | Curriculum agents (extractor, auditor, builder) produce no layout opinions. Panel agents (gatekeeper, SI, PQ) produce no curriculum opinions. |
+| **Two sources of truth** | Gatekeeper uses manual text. PQ uses hardware photos. When they disagree, Critic resolves. |

--- a/docs/pipeline-rules.md
+++ b/docs/pipeline-rules.md
@@ -1,0 +1,99 @@
+# Pipeline Rules — Lessons Learned
+
+These rules were derived from real failures across DeepMind 12 and CDJ-3000 builds. Each rule exists because violating it caused a specific, documented problem.
+
+---
+
+## 1. Sieve Extraction Strategy (Anti-Hallucination)
+
+Manual-extractor must separate **Perception** (what is on the page) from **Cognition** (how to teach it).
+
+**Process in 10-page buckets:**
+1. **Sieve** — Read 10 pages. Output raw table of exact strings + page numbers. No interpretation.
+2. **Verify** — Re-read same 10 pages. Find omissions/typos in the table.
+3. **Anchor** — Cross-reference table against panel-constants.ts. Flag discrepancies.
+4. **Checkpoint** — Write verified table. Do NOT proceed until checkpointed.
+
+**Why:** Hallucination occurs when an agent reads and interprets simultaneously over large volumes. Context drift causes paraphrased parameter names and invented menu structures.
+
+---
+
+## 2. Agent Scope Isolation
+
+Agents must not produce output outside their scope.
+
+- **Curriculum agents** (extractor, auditor, builder): NO layout diagrams, ASCII art, or spatial descriptions
+- **Panel agents** (gatekeeper, SI, PQ): NO curriculum opinions or tutorial content
+- **Tutorial builder**: Only reads checkpoints from its pipeline chain (extractor → auditor → builder)
+
+**Why:** Coverage auditor checkpoints containing layout descriptions anchor downstream agents. Panel builder should derive layout from hardware photos and manual diagrams ONLY.
+
+---
+
+## 3. Design Before Tutorials
+
+Panel design + full QA pipeline + user approval BEFORE any tutorial work.
+
+**Why:** The CDJ-3000 build went straight from panel to tutorials without QA. QA then found the panel scored 0.0/5.5. All 18 tutorials were built against a broken panel.
+
+---
+
+## 4. Enforce QA Pipeline (Never Skip Gates)
+
+The full panel QA pipeline must run: Gatekeeper → SI + PQ → Critic. No exceptions.
+
+**Why:** During the CDJ-3000 build, the orchestrating agent skipped all QA gates — going straight from panel build to tutorial building. The orchestrator agent exists but was never invoked.
+
+**Root cause:** Prioritizing throughput over process. The agents exist, the SOULs define gates, but without enforcement the orchestrating agent optimizes for speed.
+
+---
+
+## 5. Boundary Containment (No CSS Overflow)
+
+Any text or icon that overflows its container = (-1.0) Boundary Violation.
+
+**Why:** PQ scored 10/10 on CDJ-3000 despite "BEAT SYNC/INST.DOUBLES" overflowing the 32px button face. It dismissed overflow as "still legible." Physical hardware never has text spilling outside a button.
+
+**Fix options:** Resize container, reduce font, use `labelPosition="above"` (silkscreen style), or multi-line treatment.
+
+---
+
+## 6. Adversarial Blindness (PQ Independence)
+
+PQ must generate its own position map from photos/manual BEFORE reading the Gatekeeper's template.
+
+**Why:** In the DeepMind PROG section, all agents validated against a wrong Gatekeeper template. PQ scored 10/10 because it anchored to the Gatekeeper's layout instead of independently verifying. This is "circular validation" — once the Gatekeeper says it's right, nobody questions it.
+
+---
+
+## 7. Topology Before Styling
+
+Agents must verify spatial relationships (Cardinal Neighbor Tables) before checking visual properties (font-size, color, padding).
+
+**Why:** QA agents gravitate toward easy checks ("does the label match?") over hard checks ("is the button east of the slider?"). Three rounds of QA passed a section where 6 of 11 controls overflowed the section boundary — because agents checked labels first and never reached topology.
+
+---
+
+## 8. Two Sources of Truth
+
+Gatekeeper uses manual text. PQ uses hardware photos. When they disagree, Critic resolves.
+
+**Why:** Using the same source (manual p.14 diagram) for both agents creates a single point of failure. Independent sources create true adversarial verification.
+
+---
+
+## 9. Orchestrator as Root Process
+
+No QA agent runs without the orchestrator managing phase transitions. Standalone runs are "draft only" and cannot vault sections.
+
+**Why:** Manual orchestration led to skipping every gate in the pipeline. The orchestrator enforces phase transitions, priority inversion detection, and vault authorization.
+
+---
+
+## 10. PROG Blindspot (Circular Validation)
+
+If the Gatekeeper's blueprint is wrong, all downstream agents will validate the wrong thing.
+
+**Why:** Gatekeeper described the PROG rotary encoder below the LCD. All agents validated against this template. The encoder should have been to the RIGHT of the LCD. Three agents scored 10/10 on a fundamentally wrong layout.
+
+**Fix:** Gatekeeper must produce ASCII map + coarse grid + cardinal neighbors. PQ must independently derive positions. Orchestrator cross-checks both before allowing vault.

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -172,3 +172,57 @@
 - **Root cause**: Written from general synth knowledge without verifying the exact tab structure against the manual. The tab count (17) was correct but the names were wrong.
 - **Prevention rule**: System-level parameter lists, menu structures, and tab names must be copied verbatim from the manual. Never invent or guess menu item names, even if you know the count. A correct count with wrong names is worse than no list at all.
 - **Automated check**: Manual — PRE-BUILD gate question 5 ("Are parameter names verified against the Parameter Guide?").
+
+---
+
+## Pattern: Circular Validation (Gatekeeper Template Bias)
+
+- **Mistake**: All QA agents validated against the Gatekeeper's template instead of independently verifying against the hardware. The Gatekeeper described the PROG rotary encoder below the LCD. All agents scored 10/10. The encoder should have been to the RIGHT of the LCD.
+- **Root cause**: Anchor bias — once the Gatekeeper says something is correct, downstream agents validate against the template, not the source material. The PQ read the Gatekeeper first, anchoring its assessment.
+- **Prevention rule**: PQ must generate its own position map from photos/manual BEFORE reading the Gatekeeper template (Adversarial Blindness Protocol). Gatekeeper must produce ASCII map + coarse grid + cardinal neighbors so there are 3 independent representations to cross-check.
+- **Automated check**: Orchestrator cross-modality consistency check — compares Gatekeeper's cardinal neighbors against PQ's independent position map. Disagreement = HALT.
+
+---
+
+## Pattern: Inventory Checking Instead of Topology Verification
+
+- **Mistake**: 3 rounds of QA passed the CDJ-3000 RIGHT-TEMPO section while 6 of 11 controls overflowed the section boundary. Agents checked "does the button exist?" and "does the label match?" but never checked "is the button inside its section?"
+- **Root cause**: Inventory checks are computationally cheaper than topology checks. Agents default to the easy check. No rule required topology verification before scoring.
+- **Prevention rule**: Agents must produce a Cardinal Neighbor Table (N/S/E/W for all controls) BEFORE scoring. Checking font-size, color, or padding before topology = Priority Inversion = automatic (-3.0) deduction. Orchestrator scans for styling keywords before topology is verified.
+- **Automated check**: Orchestrator Priority Inversion detection — rejects scores that mention styling keywords without a completed Cardinal Neighbor Table.
+
+---
+
+## Pattern: Label Overflow (Boundary Violation)
+
+- **Mistake**: PQ scored 10/10 on CDJ-3000 RIGHT-TEMPO despite "BEAT SYNC/INST.DOUBLES" text overflowing the 32px button face. PQ dismissed it as "still legible."
+- **Root cause**: PQ's rubric had no explicit deduction for label overflow. "Legible" is too low a bar. Physical hardware never has text spilling outside a button.
+- **Prevention rule**: Any label/icon that overflows its container = (-1.0) Boundary Violation. "Still legible" is NOT sufficient. Fix by resizing container, reducing font, using labelPosition="above" (silkscreen style), or multi-line treatment.
+- **Automated check**: SI measures all label bounding rects against section boundaries. Critic can veto PQ scores that miss overflows.
+
+---
+
+## Pattern: Skipped QA Pipeline (Throughput Over Process)
+
+- **Mistake**: CDJ-3000 panel was built and 18 tutorials were created without running Gatekeeper, SI, PQ, or Critic. The orchestrator agent was never invoked. QA was run after the fact and found the panel scored 0.0/5.5.
+- **Root cause**: The orchestrating agent optimized for speed and skipped every gate. The pipeline is documented but there's nothing that forces compliance without the orchestrator.
+- **Prevention rule**: The Orchestrator is the ROOT PROCESS. No QA agent runs without orchestrator managing phase transitions. Standalone runs are "draft only" and cannot vault. Design phases must complete before tutorial phases. User must approve panel visually before tutorials are built.
+- **Automated check**: Tutorial-builder pre-conditions must verify critic checkpoint exists with score ≥9.5 before proceeding.
+
+---
+
+## Pattern: Sieve Extraction (Hallucination Over Long Manual Reads)
+
+- **Mistake**: Manual extractor paraphrased parameter names and fabricated menu structures when reading large page ranges. Context drift over 89+ page manuals causes the agent to "remember" details incorrectly.
+- **Root cause**: Reading and interpreting simultaneously over large volumes. By the time the agent processes page 80, details from page 20 are fading from context.
+- **Prevention rule**: Separate Perception from Cognition. Read in 10-page buckets: Sieve (raw extraction) → Verify (re-read same pages) → Anchor (cross-reference constants) → Checkpoint. Only after the entire manual is sieved does the agent design curriculum.
+- **Automated check**: Manual extractor checkpoint must include per-bucket verification status. Coverage auditor independently verifies.
+
+---
+
+## Pattern: Wrong LED Color (Unchecked Hardware Assumption)
+
+- **Mistake**: CDJ-3000 MASTER TEMPO LED was coded as green (`CDJ_COLORS.ledGreen`). Hardware uses orange/amber — visually distinct from the blue sync group LEDs. No agent caught this in 3 QA rounds.
+- **Root cause**: LED color was assumed, not verified against hardware. Standard QA checked "does the LED exist?" not "is it the right color?"
+- **Prevention rule**: Every LED color must be verified against hardware photos or manual descriptions. The Critic deep review specifically checks LED colors against hardware. Different functional groups should use visually distinct LED colors.
+- **Automated check**: Critic includes LED color verification in its per-control audit. Panel builder must document LED color source (manual page or photo) for each LED.


### PR DESCRIPTION
## Summary
Consolidates all pipeline lessons from DeepMind 12 and CDJ-3000 builds into enforceable hard gates across all 8 agent SOULs.

**These are instrument-agnostic rules that apply to ALL future builds.**

## Agent SOUL Updates
- **gatekeeper**: ASCII topology map is a hard gate (no map = project stalled)
- **panel-questioner**: Adversarial Blindness Protocol — must generate blind position map BEFORE reading gatekeeper template. Containment veto for label overflow.
- **structural-inspector**: Cardinal Neighbor Table mandatory before scoring. Topology Gate blocks styling checks.
- **orchestrator**: Priority Inversion detection (styling before topology = score invalidation). Root Process rule (only orchestrator can vault).
- **critic**: Boundary Violation enforcement with veto power over PQ
- **manual-extractor**: Sieve protocol (Phase A perception / Phase B cognition separation)
- **tutorial-builder**: Agent memory isolation (only reads own pipeline chain)
- **coverage-auditor**: Scope isolation (no layout opinions)

## New Documentation
- **CLAUDE.md**: Added "Instrument Build Pipeline" section with mandatory order + hard rules table
- **docs/pipeline-rules.md**: 10 consolidated lessons with root cause + fix for each

## Why This Matters
| Problem | What Happened | Rule Added |
|---------|--------------|------------|
| Circular validation | PROG section scored 10/10 with wrong layout — all agents anchored to wrong gatekeeper template | Adversarial Blindness |
| Inventory over topology | 3 QA rounds missed 6/11 controls overflowing section boundary | Topology-First, Cardinal Neighbors |
| Label overflow | PQ scored 10/10 despite text spilling outside buttons | Containment Veto |
| Skipped QA pipeline | Tutorials built against unvalidated panel | Orchestrator Root Process |
| Hallucinated parameters | Agent paraphrased manual content over long reads | Sieve Extraction |

## Test plan
- [x] `npm run build` — zero errors
- [x] `npm test` — all tests pass
- [ ] Run next instrument build with these rules and verify enforcement

🤖 Generated with [Claude Code](https://claude.com/claude-code)