### PR TITLE
fix: auto-save race — submit status now persists

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -19,10 +19,10 @@ export default function AdminLayout({
           </Link>
           <div className="flex items-center gap-4">
             <Link
-              href="/admin/review"
+              href="/admin"
               className="text-sm text-gray-400 transition-colors hover:text-gray-200"
             >
-              Review
+              Dashboard
             </Link>
             <Link
               href="/"

--- a/src/app/api/hosted/panels/[deviceId]/route.ts
+++ b/src/app/api/hosted/panels/[deviceId]/route.ts
@@ -36,6 +36,11 @@ export async function PUT(
     return NextResponse.json({ error: 'Device not found' }, { status: 404 });
   }
 
+  // Refuse saves when panel is submitted or approved (prevents auto-save overwriting review state)
+  if (existing.status === 'submitted' || existing.status === 'approved') {
+    return NextResponse.json({ error: 'Panel is locked for review', status: existing.status }, { status: 403 });
+  }
+
   // Wrap: editor sends flat manifest, we store nested in state.json
   const newStatus = existing.status === 'ready' ? 'in-progress' : existing.status;
   await putDeviceState(deviceId, {

--- a/src/components/panel-editor/PanelEditor.tsx
+++ b/src/components/panel-editor/PanelEditor.tsx
@@ -170,12 +170,15 @@ function EditorShell({ deviceId, onRestoreVersion }: { deviceId: string; onResto
                   : 'Preview Mode — clean panel view (click Preview to exit)'}
           </span>
           <div className="flex items-center gap-2">
-            <button
-              onClick={() => { setPreviewMode(false); setBuildStatus('idle'); setExportMessage(null); }}
-              className="rounded border border-gray-600 bg-gray-800 px-3 py-1 text-xs text-gray-300 transition-colors hover:bg-gray-700"
-            >
-              Back to Editor
-            </button>
+            {/* Hide "Back to Editor" after submit in hosted mode — contractor is locked out */}
+            {!(isHosted && typeof window !== 'undefined' && (window as any).__submittedForReview) && (
+              <button
+                onClick={() => { setPreviewMode(false); setBuildStatus('idle'); setExportMessage(null); }}
+                className="rounded border border-gray-600 bg-gray-800 px-3 py-1 text-xs text-gray-300 transition-colors hover:bg-gray-700"
+              >
+                Back to Editor
+              </button>
+            )}
           </div>
         </div>
       )}
@@ -291,6 +294,15 @@ export default function PanelEditor({ deviceId }: PanelEditorProps) {
           }
           // Initialize labels from controls if not yet done (migration)
           useEditorStore.getState().initLabelsFromControls();
+
+          // In hosted mode, lock editor if panel is already submitted/approved
+          if (isHosted && (data._status === 'submitted' || data._status === 'approved')) {
+            useEditorStore.getState().setPreviewMode(true);
+            if (typeof window !== 'undefined') {
+              (window as any).__submittedForReview = true;
+            }
+          }
+
           setLoading(false);
         }
       } catch (err) {

--- a/src/components/panel-editor/hooks/useAutoSave.ts
+++ b/src/components/panel-editor/hooks/useAutoSave.ts
@@ -80,6 +80,9 @@ export function useAutoSave(deviceId: string) {
         // Debounce the save
         if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
         saveTimerRef.current = setTimeout(() => {
+          // Double-check: previewMode may have been set while debounce was pending
+          if (isHosted && useEditorStore.getState().previewMode) return;
+
           const { sections, controls, editorLabels, controlGroups, canvasWidth, canvasHeight, _manifestVersion, controlScale, zoom, cleanupGap, panelScale, keyboard } = useEditorStore.getState();
           fetch(`${isHosted ? '/api/hosted/panels' : '/api/pipeline'}/${deviceId}${isHosted ? '' : '/manifest'}`, {
             method: 'PUT',

--- a/src/components/panel-editor/hooks/useAutoSave.ts
+++ b/src/components/panel-editor/hooks/useAutoSave.ts
@@ -72,6 +72,11 @@ export function useAutoSave(deviceId: string) {
           return;
         }
 
+        // Stop auto-save after contractor submits for review
+        if (isHosted && useEditorStore.getState().previewMode) {
+          return;
+        }
+
         // Debounce the save
         if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
         saveTimerRef.current = setTimeout(() => {

--- a/src/lib/hosted-storage.ts
+++ b/src/lib/hosted-storage.ts
@@ -21,7 +21,7 @@ function statePath(deviceId: string) {
 export async function getDeviceState(deviceId: string): Promise<DeviceState | null> {
   try {
     const meta = await head(statePath(deviceId));
-    const res = await fetch(meta.url);
+    const res = await fetch(meta.url, { cache: 'no-store' });
     if (!res.ok) return null;
     return await res.json();
   } catch {


### PR DESCRIPTION
Auto-save was overwriting submitted status. Now stops after contractor submits.