### PR TITLE
feat: pipeline fixes + editor help drawer & joyride

### DIFF
--- a/e2e/help-drawer-test.ts
+++ b/e2e/help-drawer-test.ts
@@ -1,0 +1,274 @@
+/**
+ * Playwright test for the Editor Help Drawer and Guided Tour.
+ * Run: npx tsx e2e/help-drawer-test.ts [deviceId]
+ * Requires: dev server running on http://localhost:3000
+ */
+
+import { chromium } from 'playwright';
+import path from 'path';
+import fs from 'fs';
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
+const DEVICE_ID = process.argv[2] || 'fantom-06';
+const EDITOR_URL = `${BASE_URL}/admin/${DEVICE_ID}/editor`;
+const SCREENSHOT_DIR = path.resolve(__dirname, '../e2e-screenshots/help-drawer');
+
+fs.mkdirSync(SCREENSHOT_DIR, { recursive: true });
+
+interface TestResult {
+  name: string;
+  passed: boolean;
+  detail: string;
+  screenshot?: string;
+}
+
+async function run() {
+  const results: TestResult[] = [];
+
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({
+    viewport: { width: 1440, height: 900 },
+  });
+
+  // Set admin auth cookie
+  await context.addCookies([{
+    name: 'admin_access',
+    value: process.env.ADMIN_PASSWORD || 'miyagi2026',
+    domain: new URL(BASE_URL).hostname,
+    path: '/',
+  }]);
+
+  const page = await context.newPage();
+
+  const consoleErrors: string[] = [];
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') consoleErrors.push(msg.text());
+  });
+
+  // ── Setup: Load editor (with joyride suppressed) ───────────────────────
+  try {
+    // First visit a same-origin page to set localStorage before the editor loads
+    await page.goto(`${BASE_URL}/admin`, { waitUntil: 'domcontentloaded', timeout: 15000 });
+    await page.evaluate(() => {
+      localStorage.setItem('editor-tutorial-disabled', 'true');
+    });
+    // Now load the editor — joyride sees localStorage and won't auto-start
+    await page.goto(EDITOR_URL, { waitUntil: 'domcontentloaded', timeout: 30000 });
+    await page.waitForSelector('[data-tutorial="canvas"]', { timeout: 15000 });
+    await page.waitForTimeout(1000);
+  } catch (err) {
+    console.error('Setup failed:', err);
+    await browser.close();
+    process.exit(2);
+  }
+
+  // ── Test 1: "?" button is visible ────────────────────────────────────────
+  try {
+    const helpBtn = await page.$('button[title="Help (?)"]');
+    const isVisible = helpBtn ? await helpBtn.isVisible() : false;
+
+    const screenshotPath = path.join(SCREENSHOT_DIR, '01-help-button.png');
+    await page.screenshot({ path: screenshotPath });
+
+    results.push({
+      name: '"?" help button visible in toolbar',
+      passed: isVisible,
+      detail: isVisible ? 'Found and visible' : 'Not found or not visible',
+      screenshot: screenshotPath,
+    });
+  } catch (err) {
+    results.push({ name: '"?" help button visible', passed: false, detail: `${err}` });
+  }
+
+  // ── Test 2: Click "?" opens the help drawer ──────────────────────────────
+  try {
+    const helpBtn = await page.$('button[title="Help (?)"]');
+    await helpBtn?.click();
+    await page.waitForTimeout(500);
+
+    // Check for the drawer header
+    const drawerHeader = await page.$('h2:has-text("Editor Guide")');
+    const isOpen = drawerHeader !== null && await drawerHeader.isVisible();
+
+    const screenshotPath = path.join(SCREENSHOT_DIR, '02-drawer-open.png');
+    await page.screenshot({ path: screenshotPath });
+
+    results.push({
+      name: 'Click "?" opens help drawer',
+      passed: isOpen,
+      detail: isOpen ? 'Drawer opened with "Editor Guide" header' : 'Drawer not found',
+      screenshot: screenshotPath,
+    });
+  } catch (err) {
+    results.push({ name: 'Click "?" opens help drawer', passed: false, detail: `${err}` });
+  }
+
+  // ── Test 3: All 3 tabs render ────────────────────────────────────────────
+  try {
+    const guideTab = await page.$('button:has-text("Guide")');
+    const shortcutsTab = await page.$('button:has-text("Shortcuts")');
+    const workflowTab = await page.$('button:has-text("Workflow")');
+
+    const allPresent = guideTab !== null && shortcutsTab !== null && workflowTab !== null;
+
+    // Click Shortcuts tab
+    if (shortcutsTab) {
+      await shortcutsTab.click();
+      await page.waitForTimeout(300);
+    }
+    const hasShortcutContent = await page.$('text=Cmd+Z');
+
+    // Click Workflow tab
+    if (workflowTab) {
+      await workflowTab.click();
+      await page.waitForTimeout(300);
+    }
+    const hasWorkflowContent = await page.$('text=Open the photo overlay');
+
+    // Go back to Guide tab
+    if (guideTab) {
+      await guideTab.click();
+      await page.waitForTimeout(300);
+    }
+
+    const screenshotPath = path.join(SCREENSHOT_DIR, '03-tabs.png');
+    await page.screenshot({ path: screenshotPath });
+
+    const passed = allPresent && hasShortcutContent !== null && hasWorkflowContent !== null;
+    results.push({
+      name: 'All 3 tabs render with content',
+      passed,
+      detail: `tabs=${allPresent}, shortcuts=${hasShortcutContent !== null}, workflow=${hasWorkflowContent !== null}`,
+      screenshot: screenshotPath,
+    });
+  } catch (err) {
+    results.push({ name: 'All 3 tabs render', passed: false, detail: `${err}` });
+  }
+
+  // ── Test 4: Guide tab has collapsible sections ───────────────────────────
+  try {
+    // Canvas section is defaultOpen — check content is already visible
+    const canvasContent = await page.$('text=Move controls');
+
+    // Click "Toolbar" section
+    const toolbarSection = await page.$('button:has-text("Toolbar")');
+    if (toolbarSection) {
+      await toolbarSection.click();
+      await page.waitForTimeout(300);
+    }
+    const toolbarContent = await page.$('text=Undo / Redo');
+
+    const screenshotPath = path.join(SCREENSHOT_DIR, '04-collapsible-sections.png');
+    await page.screenshot({ path: screenshotPath });
+
+    const passed = canvasContent !== null && toolbarContent !== null;
+    results.push({
+      name: 'Guide tab has collapsible sections with content',
+      passed,
+      detail: `canvas=${canvasContent !== null}, toolbar=${toolbarContent !== null}`,
+      screenshot: screenshotPath,
+    });
+  } catch (err) {
+    results.push({ name: 'Guide collapsible sections', passed: false, detail: `${err}` });
+  }
+
+  // ── Test 5: Close drawer with backdrop click ─────────────────────────────
+  try {
+    // Click the backdrop (the semi-transparent overlay)
+    await page.click('.bg-black\\/40');
+    await page.waitForTimeout(500);
+
+    const drawerHeader = await page.$('h2:has-text("Editor Guide")');
+    const isClosed = drawerHeader === null || !(await drawerHeader.isVisible());
+
+    const screenshotPath = path.join(SCREENSHOT_DIR, '05-drawer-closed.png');
+    await page.screenshot({ path: screenshotPath });
+
+    results.push({
+      name: 'Backdrop click closes drawer',
+      passed: isClosed,
+      detail: isClosed ? 'Drawer closed' : 'Drawer still open',
+      screenshot: screenshotPath,
+    });
+  } catch (err) {
+    results.push({ name: 'Backdrop click closes drawer', passed: false, detail: `${err}` });
+  }
+
+  // ── Test 6: "Replay Guided Tour" triggers joyride ────────────────────────
+  try {
+    // Reopen drawer
+    const helpBtn = await page.$('button[title="Help (?)"]');
+    await helpBtn?.click();
+    await page.waitForTimeout(500);
+
+    // Click "Replay Guided Tour"
+    const replayBtn = await page.$('button:has-text("Replay Guided Tour")');
+    if (replayBtn) {
+      await replayBtn.click();
+    }
+    // Wait for drawer to close + joyride to start (500ms delay in code)
+    await page.waitForTimeout(1500);
+
+    // Look for joyride tooltip
+    const joyrideTooltip = await page.$('[class*="react-joyride"]')
+      ?? await page.$('[data-test-id="button-primary"]')
+      ?? await page.$('button:has-text("Next")')
+      ?? await page.$('button:has-text("Skip Tutorial")');
+
+    const screenshotPath = path.join(SCREENSHOT_DIR, '06-joyride-replay.png');
+    await page.screenshot({ path: screenshotPath });
+
+    results.push({
+      name: 'Replay Guided Tour triggers joyride',
+      passed: joyrideTooltip !== null,
+      detail: joyrideTooltip !== null ? 'Joyride tooltip found' : 'No joyride tooltip detected',
+      screenshot: screenshotPath,
+    });
+
+    // Dismiss joyride if running
+    if (joyrideTooltip) {
+      const skipBtn = await page.$('button:has-text("Skip Tutorial")');
+      if (skipBtn) await skipBtn.click();
+      await page.waitForTimeout(500);
+    }
+  } catch (err) {
+    results.push({ name: 'Replay Guided Tour', passed: false, detail: `${err}` });
+  }
+
+  // ── Report ────────────────────────────────────────────────────────────────
+  console.log('\n===================================================');
+  console.log('  Help Drawer & Guided Tour — Playwright Report  ');
+  console.log('===================================================\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  for (const r of results) {
+    const icon = r.passed ? 'PASS' : 'FAIL';
+    console.log(`  [${icon}] ${r.name}`);
+    console.log(`         ${r.detail}`);
+    if (r.screenshot) console.log(`         Screenshot: ${r.screenshot}`);
+    console.log();
+    if (r.passed) passed++;
+    else failed++;
+  }
+
+  if (consoleErrors.length > 0) {
+    console.log('  Console Errors:');
+    for (const err of consoleErrors.slice(0, 10)) {
+      console.log(`    - ${err}`);
+    }
+    console.log();
+  }
+
+  console.log(`  Total: ${passed} passed, ${failed} failed out of ${results.length}`);
+  console.log('===================================================\n');
+
+  await browser.close();
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+run().catch((err) => {
+  console.error('Fatal error:', err);
+  process.exit(2);
+});

--- a/e2e/joyride-debug.ts
+++ b/e2e/joyride-debug.ts
@@ -1,0 +1,67 @@
+/**
+ * Debug: test joyride step navigation
+ * Run: npx tsx e2e/joyride-debug.ts
+ */
+import { chromium } from 'playwright';
+
+const BASE_URL = 'http://localhost:3000';
+
+async function run() {
+  const browser = await chromium.launch({ headless: true });
+  const ctx = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+  await ctx.addCookies([{ name: 'admin_access', value: 'miyagi2026', domain: 'localhost', path: '/' }]);
+  const page = await ctx.newPage();
+
+  // Pre-clear localStorage
+  await page.goto(`${BASE_URL}/admin`, { waitUntil: 'domcontentloaded' });
+  await page.evaluate(() => localStorage.removeItem('editor-tutorial-fantom-06'));
+
+  // Load editor
+  await page.goto(`${BASE_URL}/admin/fantom-06/editor`, { waitUntil: 'domcontentloaded' });
+  await page.waitForSelector('[data-tutorial="canvas"]', { timeout: 15000 });
+  await page.waitForTimeout(3500);
+
+  // Step 0 — should be showing
+  let tooltip = await page.evaluate(() => {
+    const el = document.querySelector('.react-joyride__tooltip');
+    return el ? (el.textContent || '').substring(0, 80) : null;
+  });
+  console.log('Step 0:', tooltip ? 'VISIBLE' : 'NOT FOUND');
+  console.log('  Text:', tooltip);
+
+  // Click Next
+  const nextBtn = await page.locator('button', { hasText: 'Next' }).first();
+  const nextVisible = await nextBtn.isVisible().catch(() => false);
+  console.log('Next button:', nextVisible ? 'VISIBLE' : 'NOT FOUND');
+
+  if (nextVisible) {
+    await nextBtn.click();
+    await page.waitForTimeout(1500);
+
+    tooltip = await page.evaluate(() => {
+      const el = document.querySelector('.react-joyride__tooltip');
+      return el ? (el.textContent || '').substring(0, 80) : null;
+    });
+    console.log('Step 1:', tooltip ? 'VISIBLE' : 'NOT FOUND');
+    console.log('  Text:', tooltip);
+
+    const beacon = await page.evaluate(() => {
+      const el = document.querySelector('.react-joyride__beacon');
+      return el ? 'BEACON SHOWING (bad)' : 'no beacon (good)';
+    });
+    console.log('  Beacon:', beacon);
+
+    // Check portal state
+    const portalInfo = await page.evaluate(() => {
+      const portal = document.getElementById('react-joyride-portal');
+      if (!portal) return 'no portal';
+      return `${portal.children.length} children, innerHTML starts: ${portal.innerHTML.substring(0, 150)}`;
+    });
+    console.log('  Portal:', portalInfo);
+  }
+
+  await page.screenshot({ path: 'e2e-screenshots/help-drawer/debug-step-nav.png' });
+  await browser.close();
+}
+
+run().catch(console.error);

--- a/scripts/pipeline-runner.ts
+++ b/scripts/pipeline-runner.ts
@@ -270,6 +270,8 @@ async function run() {
       fs.mkdirSync(destDir, { recursive: true });
       fs.copyFileSync(absSource, destInWorktree);
       appendLog(deviceId, { level: 'info', message: `Copied manual to worktree: ${manualPath}` });
+    } else if (!fs.existsSync(absSource)) {
+      appendLog(deviceId, { level: 'warn', message: `Manual not found at ${manualPath} — preflight will re-download` });
     }
   }
 
@@ -289,6 +291,21 @@ async function run() {
       }
     } catch { /* ignore heartbeat errors */ }
   }, 30_000);
+
+  // Signal handlers — ensure cleanup runs when killed by cancel/restart/pause
+  const handleSignal = (signal: string) => {
+    appendLog(deviceId, { level: 'info', message: `Runner received ${signal} — cleaning up` });
+    clearInterval(heartbeatInterval);
+    state.runnerPid = null;
+    state.childPid = null;
+    if (state.status === 'running') {
+      state.status = 'paused';
+    }
+    writeState(deviceId, state);
+    process.exit(0);
+  };
+  process.on('SIGTERM', () => handleSignal('SIGTERM'));
+  process.on('SIGINT', () => handleSignal('SIGINT'));
 
   try {
     while (state.status === 'running') {

--- a/src/app/api/pipeline/[deviceId]/recover/route.ts
+++ b/src/app/api/pipeline/[deviceId]/recover/route.ts
@@ -1,32 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { execSync } from 'child_process';
 import { readState, writeState, appendLog } from '@/lib/pipeline/state-machine';
-
-function isProcessAlive(pid: number): boolean {
-  try {
-    execSync(`ps -p ${pid} -o pid= 2>/dev/null`, { encoding: 'utf-8' });
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function gracefulKill(pid: number, label: string): string {
-  if (!isProcessAlive(pid)) return `${label} (PID ${pid}) already dead`;
-
-  // SIGTERM first — gives the process a chance to clean up
-  try { process.kill(pid, 'SIGTERM'); } catch { /* ignore */ }
-
-  // Wait up to 5 seconds for graceful exit
-  for (let i = 0; i < 10; i++) {
-    execSync('sleep 0.5');
-    if (!isProcessAlive(pid)) return `${label} (PID ${pid}) exited gracefully`;
-  }
-
-  // Still alive — force kill
-  try { process.kill(pid, 'SIGKILL'); } catch { /* ignore */ }
-  return `${label} (PID ${pid}) force-killed after 5s timeout`;
-}
+import { isProcessAlive, gracefulKill } from '@/lib/pipeline/process-utils';
 
 /**
  * POST /api/pipeline/[deviceId]/recover

--- a/src/app/api/pipeline/[deviceId]/restart/route.ts
+++ b/src/app/api/pipeline/[deviceId]/restart/route.ts
@@ -9,15 +9,7 @@ import {
   ensurePipelineDir,
   appendLog,
 } from '@/lib/pipeline/state-machine';
-
-function isProcessAlive(pid: number): boolean {
-  try {
-    execSync(`ps -p ${pid} -o pid= 2>/dev/null`, { encoding: 'utf-8' });
-    return true;
-  } catch {
-    return false;
-  }
-}
+import { gracefulKill } from '@/lib/pipeline/process-utils';
 
 /**
  * POST /api/pipeline/[deviceId]/restart
@@ -40,12 +32,12 @@ export async function POST(
   // 1. Extract device metadata before wiping state
   const { deviceName, manufacturer, manualPaths, budgetCapUsd } = state;
 
-  // 2. Kill running processes
-  if (state.childPid && isProcessAlive(state.childPid)) {
-    try { process.kill(state.childPid, 'SIGTERM'); } catch { /* ignore */ }
+  // 2. Kill running processes (child first, then runner — with graceful shutdown)
+  if (state.childPid) {
+    gracefulKill(state.childPid, 'Agent');
   }
-  if (state.runnerPid && isProcessAlive(state.runnerPid)) {
-    try { process.kill(state.runnerPid, 'SIGTERM'); } catch { /* ignore */ }
+  if (state.runnerPid) {
+    gracefulKill(state.runnerPid, 'Runner');
   }
 
   const pipelineDir = path.join('.pipeline', deviceId);

--- a/src/app/api/pipeline/[deviceId]/route.ts
+++ b/src/app/api/pipeline/[deviceId]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { readState, writeState } from '@/lib/pipeline/state-machine';
+import { gracefulKill } from '@/lib/pipeline/process-utils';
 
 export async function GET(
   _request: NextRequest,
@@ -26,15 +27,18 @@ export async function DELETE(
     return NextResponse.json({ error: `No pipeline found for device: ${deviceId}` }, { status: 404 });
   }
 
+  // Kill child agent first, then runner — with graceful shutdown
+  if (state.childPid) {
+    gracefulKill(state.childPid, 'Agent');
+  }
   if (state.runnerPid) {
-    try {
-      process.kill(state.runnerPid, 'SIGTERM');
-    } catch { /* Process may have already exited */ }
+    gracefulKill(state.runnerPid, 'Runner');
   }
 
   state.status = 'failed';
   state.currentPhase = 'failed';
   state.runnerPid = null;
+  state.childPid = null;
   writeState(deviceId, state);
 
   return NextResponse.json({ status: 'cancelled' });

--- a/src/components/admin/DeviceHeader.tsx
+++ b/src/components/admin/DeviceHeader.tsx
@@ -41,7 +41,7 @@ export default function DeviceHeader({ deviceId }: DeviceHeaderProps) {
   };
 
   const handleRestart = async () => {
-    if (!confirm('Re-run the entire pipeline with latest improvements. Your editor positions will be preserved.')) return;
+    if (!confirm(`Restart pipeline for "${deviceName}"?\n\nThis will re-run the entire pipeline from scratch with the latest improvements. Your editor positions will be preserved.`)) return;
     await fetch(`/api/pipeline/${deviceId}/restart`, { method: 'POST' });
     window.location.reload();
   };

--- a/src/components/panel-editor/EditorHelpDrawer.tsx
+++ b/src/components/panel-editor/EditorHelpDrawer.tsx
@@ -1,0 +1,271 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+
+type HelpTab = 'guide' | 'shortcuts' | 'workflow';
+
+interface EditorHelpDrawerProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onReplayTour: () => void;
+}
+
+function CollapsibleSection({ title, children, defaultOpen = false }: {
+  title: string;
+  children: React.ReactNode;
+  defaultOpen?: boolean;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <div className="border-b border-white/5 last:border-0">
+      <button
+        onClick={() => setOpen(!open)}
+        className="flex w-full items-center justify-between px-5 py-3 text-left text-sm font-medium text-white/90 hover:bg-white/5 transition-colors"
+      >
+        {title}
+        <span className={`text-white/30 transition-transform text-xs ${open ? 'rotate-90' : ''}`}>
+          &#9654;
+        </span>
+      </button>
+      {open && (
+        <div className="px-5 pb-4 text-[13px] leading-relaxed text-gray-400 space-y-2">
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ShortcutRow({ action, keys }: { action: string; keys: string }) {
+  return (
+    <div className="flex items-center justify-between py-1.5 border-b border-white/5 last:border-0">
+      <span className="text-gray-400 text-[13px]">{action}</span>
+      <kbd className="rounded bg-white/10 px-2 py-0.5 text-[11px] font-mono text-gray-300">{keys}</kbd>
+    </div>
+  );
+}
+
+function GuideTab() {
+  return (
+    <div>
+      <CollapsibleSection title="Canvas" defaultOpen>
+        <p><strong className="text-white/80">Move controls</strong> &mdash; Click and drag any control to reposition it. Controls snap to your grid setting.</p>
+        <p><strong className="text-white/80">Resize</strong> &mdash; Drag the corner or edge handles that appear when a control is selected.</p>
+        <p><strong className="text-white/80">Select multiple</strong> &mdash; Click and drag on empty canvas space to draw a selection box around multiple controls. Hold Shift to add to selection, Cmd/Ctrl to toggle.</p>
+        <p><strong className="text-white/80">Right-click menu</strong> &mdash; Right-click any control for quick access to align, distribute, group, duplicate, delete, and lock/unlock.</p>
+        <p><strong className="text-white/80">Double-click a label</strong> &mdash; Edit the label text inline. Press Escape or click away to save.</p>
+      </CollapsibleSection>
+
+      <CollapsibleSection title="Toolbar">
+        <p><strong className="text-white/80">Undo / Redo</strong> &mdash; Every action is reversible. Use Cmd+Z / Cmd+Shift+Z or the toolbar buttons.</p>
+        <p><strong className="text-white/80">Snap Grid</strong> &mdash; Controls the pixel grid that controls snap to when dragged. Smaller values (1-2px) for precision, larger (8-16px) for fast rough positioning.</p>
+        <p><strong className="text-white/80">Zoom</strong> &mdash; Changes your view magnification. Does not affect the actual panel size &mdash; purely for comfort while editing.</p>
+        <p><strong className="text-white/80">Grid overlay</strong> &mdash; Shows thin guidelines at the snap interval. Helps you see alignment at a glance. Toggle with <kbd className="rounded bg-white/10 px-1 text-[11px] font-mono">G</kbd>.</p>
+        <p><strong className="text-white/80">Labels</strong> &mdash; Show/hide text labels on all controls. Toggle with <kbd className="rounded bg-white/10 px-1 text-[11px] font-mono">T</kbd>.</p>
+        <p><strong className="text-white/80">Canvas Size (W &times; H)</strong> &mdash; Set exact pixel dimensions for the panel canvas. Match these to the reference photo proportions.</p>
+        <p><strong className="text-white/80">Preview</strong> &mdash; Shows the panel as end users will see it. Use this to check your work before submitting.</p>
+        <p><strong className="text-white/80">Submit for Review</strong> &mdash; Sends your work to the admin for review. You can add an optional note. The editor locks until the admin responds.</p>
+      </CollapsibleSection>
+
+      <CollapsibleSection title="Photo Overlay">
+        <p>The photo overlay lets you see the real hardware underneath your controls so you can match positions exactly.</p>
+        <p><strong className="text-white/80">Side-by-side mode</strong> &mdash; Shows the photo next to the canvas with a draggable divider. Good for comparing layout at a glance.</p>
+        <p><strong className="text-white/80">Overlay mode</strong> &mdash; Places the photo directly under your controls with adjustable opacity. Set opacity to 40-50% so you can see both layers.</p>
+        <p><strong className="text-white/80">Offset (X/Y)</strong> &mdash; Shift the photo position to align it precisely with your canvas. Use Reset to zero out.</p>
+        <p>Toggle with <kbd className="rounded bg-white/10 px-1 text-[11px] font-mono">P</kbd>.</p>
+      </CollapsibleSection>
+
+      <CollapsibleSection title="Layers Panel">
+        <p>Press <kbd className="rounded bg-white/10 px-1 text-[11px] font-mono">L</kbd> to open. Shows all sections and their controls in a tree view.</p>
+        <p><strong className="text-white/80">Sections</strong> &mdash; Logical groups like &ldquo;MIXER&rdquo;, &ldquo;TRANSPORT&rdquo;, &ldquo;EFFECTS&rdquo;. Click the arrow to expand and see child controls.</p>
+        <p><strong className="text-white/80">Click a control</strong> &mdash; Selects it on the canvas and scrolls to it. Shift-click to add to selection.</p>
+        <p><strong className="text-white/80">Groups</strong> &mdash; Shown with a violet dashed border. Expand to see members. Selecting a group member auto-expands its group.</p>
+      </CollapsibleSection>
+
+      <CollapsibleSection title="Properties Panel">
+        <p>Appears on the right when you select a control. Shows and lets you edit all properties.</p>
+        <p><strong className="text-white/80">Type</strong> &mdash; Change what kind of control this is (button, knob, slider, pad, etc.).</p>
+        <p><strong className="text-white/80">Label</strong> &mdash; Edit label text and choose position: above, below, left, right, on the button, or hidden.</p>
+        <p><strong className="text-white/80">X, Y, W, H</strong> &mdash; Set exact pixel position and size. Good for fine-tuning after dragging.</p>
+        <p><strong className="text-white/80">Align tools</strong> &mdash; Select 2+ controls, then align them: left edges, centers, or right edges (horizontal); top, middle, or bottom (vertical). &ldquo;Align&rdquo; means &ldquo;straighten into a line.&rdquo;</p>
+        <p><strong className="text-white/80">Distribute</strong> &mdash; Select 3+ controls to space them equally. Horizontal distribute makes even gaps left-to-right; vertical does top-to-bottom.</p>
+        <p><strong className="text-white/80">Gap</strong> &mdash; Set an exact pixel distance between selected controls. Type a number, hit enter.</p>
+      </CollapsibleSection>
+
+      <CollapsibleSection title="Grouping Controls">
+        <p>Select 2+ controls and press <kbd className="rounded bg-white/10 px-1 text-[11px] font-mono">Cmd+G</kbd> to group them. Groups:</p>
+        <p>&bull; Move together when you drag any member</p>
+        <p>&bull; Align as a unit with the alignment tools</p>
+        <p>&bull; Show as a unit in the Layers panel</p>
+        <p>Press <kbd className="rounded bg-white/10 px-1 text-[11px] font-mono">Cmd+Shift+G</kbd> to ungroup.</p>
+      </CollapsibleSection>
+    </div>
+  );
+}
+
+function ShortcutsTab() {
+  return (
+    <div className="px-5 py-4 space-y-4">
+      <div>
+        <h4 className="text-[11px] font-bold uppercase tracking-widest text-white/30 mb-2">General</h4>
+        <ShortcutRow action="Undo" keys="Cmd+Z" />
+        <ShortcutRow action="Redo" keys="Cmd+Shift+Z" />
+        <ShortcutRow action="Delete selection" keys="Backspace" />
+        <ShortcutRow action="Duplicate" keys="Cmd+D" />
+        <ShortcutRow action="Clear selection" keys="Escape" />
+      </div>
+      <div>
+        <h4 className="text-[11px] font-bold uppercase tracking-widest text-white/30 mb-2">View Toggles</h4>
+        <ShortcutRow action="Grid overlay" keys="G" />
+        <ShortcutRow action="Photo overlay" keys="P" />
+        <ShortcutRow action="Layers panel" keys="L" />
+        <ShortcutRow action="Labels" keys="T" />
+        <ShortcutRow action="Zoom in" keys="Cmd+=" />
+        <ShortcutRow action="Zoom out" keys="Cmd+-" />
+        <ShortcutRow action="Open help" keys="?" />
+      </div>
+      <div>
+        <h4 className="text-[11px] font-bold uppercase tracking-widest text-white/30 mb-2">Alignment</h4>
+        <ShortcutRow action="Align centers horizontally" keys="Shift+H" />
+        <ShortcutRow action="Align centers vertically" keys="Shift+V" />
+        <ShortcutRow action="Distribute horizontal" keys="Cmd+Shift+H" />
+        <ShortcutRow action="Distribute vertical" keys="Cmd+Shift+V" />
+      </div>
+      <div>
+        <h4 className="text-[11px] font-bold uppercase tracking-widest text-white/30 mb-2">Grouping</h4>
+        <ShortcutRow action="Group selected" keys="Cmd+G" />
+        <ShortcutRow action="Ungroup" keys="Cmd+Shift+G" />
+      </div>
+    </div>
+  );
+}
+
+function WorkflowTab() {
+  const steps = [
+    { title: 'Open the photo overlay', desc: 'Press P or click the Photo button. Switch to Overlay mode and set opacity to around 40-50% so you can see the real hardware under your controls.' },
+    { title: 'Adjust canvas size', desc: 'Set the W and H values in the toolbar to match the photo proportions. This ensures controls are positioned at the right scale.' },
+    { title: 'Position controls on the photo', desc: 'Drag each control to match its real position on the hardware. Start with the big, obvious ones (knobs, sliders, screens) then refine smaller controls.' },
+    { title: 'Align rows and columns', desc: 'Select a row of controls, press Shift+H to align their centers. Select a column, press Shift+V. This straightens everything into clean lines.' },
+    { title: 'Distribute for even spacing', desc: 'Select 3+ controls in a row/column, then Cmd+Shift+H (horizontal) or Cmd+Shift+V (vertical) to space them equally.' },
+    { title: 'Fine-tune with Gap inputs', desc: 'In the Properties panel, use the Gap (H/V) inputs to set exact pixel spacing between controls. Good for knob rows that need uniform gaps.' },
+    { title: 'Group related controls', desc: 'Select controls that belong together (e.g., a row of channel faders) and press Cmd+G. Groups move together and won\'t accidentally get misaligned.' },
+    { title: 'Preview your work', desc: 'Click Preview in the toolbar to see the panel as the end user will see it. Check that labels are readable and nothing overlaps.' },
+    { title: 'Submit for review', desc: 'Click Submit for Review. Add an optional note about any tricky areas. The editor locks while the admin reviews. You\'ll see feedback on the instrument list if changes are needed.' },
+  ];
+
+  return (
+    <div className="px-5 py-4 space-y-1">
+      <p className="text-[13px] text-gray-500 mb-4">A typical editing session, start to finish:</p>
+      {steps.map((step, i) => (
+        <div key={i} className="flex gap-3 py-2.5 border-b border-white/5 last:border-0">
+          <span className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-blue-500/15 text-[11px] font-bold text-blue-400">
+            {i + 1}
+          </span>
+          <div>
+            <p className="text-[13px] font-medium text-white/85">{step.title}</p>
+            <p className="text-[12px] text-gray-500 mt-0.5 leading-relaxed">{step.desc}</p>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+const TAB_LABELS: Record<HelpTab, string> = {
+  guide: 'Guide',
+  shortcuts: 'Shortcuts',
+  workflow: 'Workflow',
+};
+
+export default function EditorHelpDrawer({ isOpen, onClose, onReplayTour }: EditorHelpDrawerProps) {
+  const [activeTab, setActiveTab] = useState<HelpTab>('guide');
+  // Reset tab when drawer closes
+  useEffect(() => {
+    if (!isOpen) setActiveTab('guide');
+  }, [isOpen]);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [isOpen, onClose]);
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          className="fixed inset-0 z-50 flex justify-end"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.15 }}
+        >
+          {/* Backdrop */}
+          <div className="absolute inset-0 bg-black/40" onClick={onClose} />
+
+          {/* Drawer */}
+          <motion.div
+            className="relative w-full max-w-sm h-full bg-[#0f0f1a] border-l border-white/10 flex flex-col"
+            initial={{ x: '100%' }}
+            animate={{ x: 0 }}
+            exit={{ x: '100%' }}
+            transition={{ type: 'spring', damping: 30, stiffness: 300 }}
+          >
+            {/* Header */}
+            <div className="flex items-center justify-between px-5 py-4 border-b border-white/10 flex-shrink-0">
+              <div>
+                <h2 className="text-base font-semibold text-white">Editor Guide</h2>
+                <p className="text-[11px] text-white/30 mt-0.5">Reference &middot; always available with ?</p>
+              </div>
+              <button
+                onClick={onClose}
+                className="rounded-lg p-1.5 text-white/40 hover:bg-white/10 hover:text-white/80 transition-colors"
+              >
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M4 4l8 8M12 4l-8 8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" /></svg>
+              </button>
+            </div>
+
+            {/* Tabs */}
+            <div className="flex gap-1 px-5 py-2.5 border-b border-white/5 flex-shrink-0">
+              {(Object.keys(TAB_LABELS) as HelpTab[]).map((tab) => (
+                <button
+                  key={tab}
+                  onClick={() => setActiveTab(tab)}
+                  className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+                    activeTab === tab
+                      ? 'bg-blue-500/15 text-blue-400'
+                      : 'text-white/40 hover:bg-white/5 hover:text-white/60'
+                  }`}
+                >
+                  {TAB_LABELS[tab]}
+                </button>
+              ))}
+            </div>
+
+            {/* Tab content */}
+            <div className="flex-1 overflow-y-auto">
+              {activeTab === 'guide' && <GuideTab />}
+              {activeTab === 'shortcuts' && <ShortcutsTab />}
+              {activeTab === 'workflow' && <WorkflowTab />}
+            </div>
+
+            {/* Footer: replay tour */}
+            <div className="border-t border-white/10 px-5 py-3 flex-shrink-0">
+              <button
+                onClick={onReplayTour}
+                className="w-full rounded-lg border border-white/10 py-2 text-xs font-medium text-white/50 hover:bg-white/5 hover:text-white/70 transition-colors"
+              >
+                Replay Guided Tour
+              </button>
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/components/panel-editor/EditorToolbar.tsx
+++ b/src/components/panel-editor/EditorToolbar.tsx
@@ -96,6 +96,7 @@ interface EditorToolbarProps {
   onTogglePreview: () => void;
   onReportIssue?: () => void;
   onRestoreVersion?: () => void;
+  onToggleHelp?: () => void;
 }
 
 export default function EditorToolbar({
@@ -107,6 +108,7 @@ export default function EditorToolbar({
   onTogglePreview,
   onReportIssue,
   onRestoreVersion,
+  onToggleHelp,
 }: EditorToolbarProps) {
   const manufacturer = useEditorStore((s) => s.manufacturer);
   const deviceName = useEditorStore((s) => s.deviceName);
@@ -186,18 +188,6 @@ export default function EditorToolbar({
 
       {divider}
 
-      {/* Snap */}
-      <select
-        value={snapGrid}
-        onChange={(e) => setSnapGrid(Number(e.target.value) as SnapGrid)}
-        className="h-6 rounded border border-gray-700 bg-gray-900 px-1 text-[10px] text-gray-300 outline-none"
-        title="Snap Grid"
-      >
-        {SNAP_OPTIONS.map((v) => (
-          <option key={v} value={v}>{v}px</option>
-        ))}
-      </select>
-
       {/* Zoom */}
       <div className="flex items-center gap-0.5">
         <button onClick={() => setZoom(zoom - ZOOM_STEP)} disabled={zoom <= 0.1} className={iconBtn} title="Zoom Out">-</button>
@@ -205,14 +195,25 @@ export default function EditorToolbar({
         <button onClick={() => setZoom(zoom + ZOOM_STEP)} disabled={zoom >= 5} className={iconBtn} title="Zoom In">+</button>
       </div>
 
-      {/* Control Scale slider — HIDDEN for now (redundant with Zoom).
-          Keep code intact for potential future use. Use Zoom or Canvas W×H instead. */}
-
       {divider}
 
       {/* ── MIDDLE: Overlays ───────────────────────────────────── */}
 
-      <button data-tutorial="grid" onClick={toggleGrid} className={toggleBtn(showGrid)} title="Grid (G)" disabled={previewMode}>Grid</button>
+      {/* Grid toggle + snap size — grouped so the relationship is obvious */}
+      <div className="flex items-center gap-0.5" data-tutorial="grid">
+        <button onClick={toggleGrid} className={toggleBtn(showGrid)} title="Grid (G)" disabled={previewMode}>Grid</button>
+        <select
+          value={snapGrid}
+          onChange={(e) => setSnapGrid(Number(e.target.value) as SnapGrid)}
+          className="h-6 rounded border border-gray-700 bg-gray-900 px-1 text-[10px] text-gray-300 outline-none"
+          title="Snap grid size — controls snap to this interval when dragging"
+          disabled={previewMode}
+        >
+          {SNAP_OPTIONS.map((v) => (
+            <option key={v} value={v}>{v}px</option>
+          ))}
+        </select>
+      </div>
 
       <button onClick={toggleLabels} className={toggleBtn(showLabels)} title="Labels (T)" disabled={previewMode}>Labels</button>
 
@@ -312,7 +313,15 @@ export default function EditorToolbar({
 
       {/* ── RIGHT: Actions ─────────────────────────────────────── */}
 
-      {/* History + Report + Help — local only */}
+      {/* Help — always visible (contractors need this) */}
+      <button
+        onClick={onToggleHelp}
+        className={iconBtn}
+        title="Help (?)"
+        data-tutorial="help"
+      >?</button>
+
+      {/* History + Report — local only */}
       {!isHosted && (
         <>
           <VersionHistoryDropdown deviceId={deviceId} onRestore={onRestoreVersion} />
@@ -322,12 +331,6 @@ export default function EditorToolbar({
               <span className="text-[10px]">⚑</span>
             </button>
           )}
-
-          <button
-            onClick={() => window.dispatchEvent(new Event('editor-tutorial-replay'))}
-            className={iconBtn}
-            title="Help"
-          >?</button>
 
           {/* Reset Sizes */}
           <button
@@ -409,13 +412,15 @@ export default function EditorToolbar({
         </div>
 
         {isHosted ? (
-          (typeof window !== 'undefined' && (window as any).__submittedForReview) ? (
-            <span className="flex h-7 items-center px-3 text-[10px] font-medium text-green-400 border border-green-700 bg-green-700/20 rounded whitespace-nowrap">
-              Submitted ✓
-            </span>
-          ) : (
-            <SubmitForReviewButton deviceId={deviceId} disabled={previewMode} />
-          )
+          <div data-tutorial="submit">
+            {(typeof window !== 'undefined' && (window as any).__submittedForReview) ? (
+              <span className="flex h-7 items-center px-3 text-[10px] font-medium text-green-400 border border-green-700 bg-green-700/20 rounded whitespace-nowrap">
+                Submitted ✓
+              </span>
+            ) : (
+              <SubmitForReviewButton deviceId={deviceId} disabled={previewMode} />
+            )}
+          </div>
         ) : (
           <button
             data-tutorial="approve"

--- a/src/components/panel-editor/EditorTutorial.tsx
+++ b/src/components/panel-editor/EditorTutorial.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import dynamic from 'next/dynamic';
+import { isHosted } from '@/lib/env';
 
 // Dynamic import — react-joyride exports named `Joyride`, not default
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -14,87 +15,118 @@ interface EditorTutorialProps {
   deviceId: string;
 }
 
-const STORAGE_KEY_PREFIX = 'editor-tutorial-';
+const DISABLED_KEY = 'editor-tutorial-disabled';
 
-const steps = [
+// Every step gets skipBeacon + skip button so users can bail out at any point
+const stepDefaults = {
+  skipBeacon: true,
+  buttons: ['skip' as const, 'back' as const, 'primary' as const],
+};
+
+const sharedSteps = [
   {
+    ...stepDefaults,
     target: '[data-tutorial="canvas"]',
-    content: 'This is your instrument canvas. Controls are pre-loaded from the pipeline. Drag them to position on the hardware photo.',
-    disableBeacon: true,
+    content: 'This is your instrument canvas. All controls are pre-loaded — your job is to drag them into position to match the real hardware. Click and drag to move, use corner handles to resize.',
+    placement: 'center' as const,
   },
   {
-    target: '[data-tutorial="scale"]',
-    content: 'Scale controls down (30-50%) to match the hardware photo proportions. Use [ and ] keys for quick adjustment. Scale back to 100% to see the final result.',
-  },
-  {
+    ...stepDefaults,
     target: '[data-tutorial="photo"]',
-    content: 'Toggle the photo overlay to see the real hardware underneath. Align controls to match the photo.',
+    content: 'Toggle the photo overlay to see the real hardware underneath your controls. Use Overlay mode with ~40-50% opacity for the best results. Adjust the X/Y offset to align the photo with your canvas.',
   },
   {
+    ...stepDefaults,
     target: '[data-tutorial="grid"]',
-    content: 'Show the alignment grid for consistent spacing. Change grid size with the Snap dropdown.',
+    content: 'Show the alignment grid for consistent spacing. Change the snap size with the dropdown — use 1-2px for precision work, 8-16px for rough positioning.',
   },
   {
+    ...stepDefaults,
     target: '[data-tutorial="layers"]',
-    content: 'Press L to open the Layers panel — shows sections and controls organized by group. Click a control here to select it on the canvas.',
-  },
-  {
-    target: '[data-tutorial="report"]',
-    content: 'Found a missing control or wrong label? Click Report Issue to flag it without touching any code.',
-  },
-  {
-    target: '[data-tutorial="approve"]',
-    content: 'When positioning is done, click Approve & Build to generate the final instrument panel from your layout.',
+    content: 'Press L to open the Layers panel. It shows all sections and controls in a tree view. Click any control here to select it on the canvas. Shift-click to select multiple.',
   },
 ];
 
-export default function EditorTutorial({ deviceId }: EditorTutorialProps) {
+// Local-only steps (targets hidden in hosted mode)
+const localSteps = [
+  {
+    ...stepDefaults,
+    target: '[data-tutorial="report"]',
+    content: 'Found a missing control, wrong label, or incorrect type? Click Report Issue to flag it. The admin will see your report and fix it in the pipeline.',
+  },
+  {
+    ...stepDefaults,
+    target: '[data-tutorial="approve"]',
+    content: 'When you\'re happy with the layout, click Export Panel to generate the final manifest from your layout.',
+  },
+];
+
+// Hosted-mode steps (contractor sees Submit button, not Export/Report)
+const hostedSteps = [
+  {
+    ...stepDefaults,
+    target: '[data-tutorial="submit"]',
+    content: 'When you\'re done positioning, click Submit for Review. You can add a note about anything tricky. The admin will review and either approve or send feedback.',
+  },
+  {
+    ...stepDefaults,
+    target: '[data-tutorial="help"]',
+    content: 'Need help anytime? Click the ? button to open the full editor guide with shortcuts, alignment tools, and a step-by-step workflow.',
+  },
+];
+
+function getSteps() {
+  return isHosted ? [...sharedSteps, ...hostedSteps] : [...sharedSteps, ...localSteps];
+}
+
+export default function EditorTutorial({ deviceId: _deviceId }: EditorTutorialProps) {
   const [run, setRun] = useState(false);
   const [mounted, setMounted] = useState(false);
-
-  const storageKey = `${STORAGE_KEY_PREFIX}${deviceId}`;
+  const [tourKey, setTourKey] = useState(0); // Increment to force joyride remount
 
   useEffect(() => {
     setMounted(true);
-    // Check if tutorial was already completed
     try {
-      const completed = localStorage.getItem(storageKey);
-      if (!completed) {
-        // Delay start to let editor render first
+      // Only auto-start if user has never seen/skipped the tour
+      const disabled = localStorage.getItem(DISABLED_KEY) === 'true';
+      if (!disabled) {
         setTimeout(() => setRun(true), 2000);
       }
     } catch {
       // localStorage not available
     }
-  }, [storageKey]);
+  }, []);
 
-  const handleCallback = (data: { status: string; type: string }) => {
+  const handleCallback = (data: { status: string }) => {
     if (data.status === 'finished' || data.status === 'skipped') {
       try {
-        localStorage.setItem(storageKey, 'completed');
+        // Permanently disable auto-start — skip or complete = opted out
+        localStorage.setItem(DISABLED_KEY, 'true');
       } catch { /* ignore */ }
       setRun(false);
     }
   };
 
-  // Re-trigger from outside (via "?" button)
+  // Re-trigger from outside (via help drawer "Replay" button)
+  // This is a one-shot replay — doesn't re-enable auto-start
   useEffect(() => {
     const handler = () => {
-      try { localStorage.removeItem(storageKey); } catch { /* ignore */ }
-      setRun(true);
+      setRun(false);
+      setTourKey((k) => k + 1);
+      setTimeout(() => setRun(true), 500);
     };
     window.addEventListener('editor-tutorial-replay', handler);
     return () => window.removeEventListener('editor-tutorial-replay', handler);
-  }, [storageKey]);
+  }, []);
 
   if (!mounted) return null;
 
   return (
     <JoyrideComponent
-      steps={steps}
+      key={tourKey}
+      steps={getSteps()}
       run={run}
       continuous
-      showSkipButton
       showProgress
       callback={handleCallback}
       styles={{
@@ -103,7 +135,7 @@ export default function EditorTutorial({ deviceId }: EditorTutorialProps) {
           textColor: '#e0e0e0',
           primaryColor: '#3b82f6',
           arrowColor: '#1a1a2e',
-          zIndex: 200,
+          zIndex: 10000,
         },
         tooltip: {
           borderRadius: 8,

--- a/src/components/panel-editor/PanelEditor.tsx
+++ b/src/components/panel-editor/PanelEditor.tsx
@@ -11,6 +11,7 @@ import LayersPanel from './LayersPanel';
 import ContextMenu from './ContextMenu';
 import IssueReportModal from './IssueReportModal';
 import EditorTutorial from './EditorTutorial';
+import EditorHelpDrawer from './EditorHelpDrawer';
 import { useEditorKeyboard } from './hooks/useEditorKeyboard';
 import { useAutoSave } from './hooks/useAutoSave';
 import { computeManifestVersion } from '@/lib/pipeline/manifest-version';
@@ -34,6 +35,14 @@ function EditorShell({ deviceId, onRestoreVersion, adminNote }: { deviceId: stri
   const [exportMessage, setExportMessage] = useState<string | null>(null);
   const [noteExpanded, setNoteExpanded] = useState(false);
   const [showIssueModal, setShowIssueModal] = useState(false);
+  const [showHelp, setShowHelp] = useState(false);
+
+  // Listen for help toggle from keyboard shortcut
+  useEffect(() => {
+    const handler = () => setShowHelp((s) => !s);
+    window.addEventListener('editor-help-toggle', handler);
+    return () => window.removeEventListener('editor-help-toggle', handler);
+  }, []);
 
   // ── Clean Up: optional inference pass (snap rows, equalize spacing) ──────
   const handleCleanUp = useCallback(() => {
@@ -141,6 +150,7 @@ function EditorShell({ deviceId, onRestoreVersion, adminNote }: { deviceId: stri
         }}
         onReportIssue={() => setShowIssueModal(true)}
         onRestoreVersion={onRestoreVersion}
+        onToggleHelp={() => setShowHelp((s) => !s)}
       />
 
       {/* Codegen error banner — local only */}
@@ -216,6 +226,15 @@ function EditorShell({ deviceId, onRestoreVersion, adminNote }: { deviceId: stri
           onClose={() => setShowIssueModal(false)}
         />
       )}
+
+      <EditorHelpDrawer
+        isOpen={showHelp}
+        onClose={() => setShowHelp(false)}
+        onReplayTour={() => {
+          setShowHelp(false);
+          window.dispatchEvent(new Event('editor-tutorial-replay'));
+        }}
+      />
     </div>
   );
 }

--- a/src/components/panel-editor/hooks/useEditorKeyboard.ts
+++ b/src/components/panel-editor/hooks/useEditorKeyboard.ts
@@ -157,6 +157,13 @@ export function useEditorKeyboard() {
       // [ and ] shortcuts removed — controlScale hidden for now (redundant with Zoom).
       // Use Cmd+= / Cmd+- for Zoom instead.
 
+      // ── Help drawer: ? (Shift+/) ─────────────────────────────────────────
+      if (e.key === '?' && !isMod) {
+        e.preventDefault();
+        window.dispatchEvent(new Event('editor-help-toggle'));
+        return;
+      }
+
       // ── Escape: clear selection ───────────────────────────────────────────
       if (e.key === 'Escape') {
         store.setSelectedIds([]);

--- a/src/lib/pipeline/process-utils.ts
+++ b/src/lib/pipeline/process-utils.ts
@@ -1,0 +1,34 @@
+import { execSync } from 'child_process';
+
+/**
+ * Check if a process is still alive by PID.
+ */
+export function isProcessAlive(pid: number): boolean {
+  try {
+    execSync(`ps -p ${pid} -o pid= 2>/dev/null`, { encoding: 'utf-8' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Gracefully kill a process: SIGTERM first, wait up to 5 seconds, then SIGKILL.
+ * Returns a human-readable status string.
+ */
+export function gracefulKill(pid: number, label: string): string {
+  if (!isProcessAlive(pid)) return `${label} (PID ${pid}) already dead`;
+
+  // SIGTERM first — gives the process a chance to clean up
+  try { process.kill(pid, 'SIGTERM'); } catch { /* ignore */ }
+
+  // Wait up to 5 seconds for graceful exit
+  for (let i = 0; i < 10; i++) {
+    execSync('sleep 0.5');
+    if (!isProcessAlive(pid)) return `${label} (PID ${pid}) exited gracefully`;
+  }
+
+  // Still alive — force kill
+  try { process.kill(pid, 'SIGKILL'); } catch { /* ignore */ }
+  return `${label} (PID ${pid}) force-killed after 5s timeout`;
+}

--- a/src/lib/pipeline/runner.ts
+++ b/src/lib/pipeline/runner.ts
@@ -135,7 +135,7 @@ export function invokeAgent(opts: {
       message: `Starting ${opts.agent} invocation${opts.cwd ? ` (cwd: ${opts.cwd})` : ''}`,
     });
 
-    const proc = spawn('npx', ['claude', ...args], {
+    const proc = spawn('claude', args, {
       stdio: ['ignore', 'pipe', 'pipe'],
       cwd: opts.cwd,
       env: { ...process.env },

--- a/src/lib/pipeline/state-machine.ts
+++ b/src/lib/pipeline/state-machine.ts
@@ -350,12 +350,14 @@ export function createWorktree(deviceId: string, branch: string): string {
   }
   execSync('git worktree prune', { stdio: 'pipe' });
 
-  // Create the branch from test if it doesn't exist
+  // Delete old branch if it exists, then create fresh from test.
+  // Without this, restart re-uses a stale branch that may have diverged from test.
   try {
-    execSync(`git branch "${branch}" test 2>/dev/null`, { stdio: 'pipe' });
+    execSync(`git branch -D "${branch}" 2>/dev/null`, { stdio: 'pipe' });
   } catch {
-    // Branch already exists — fine
+    // Branch didn't exist — fine
   }
+  execSync(`git branch "${branch}" test`, { stdio: 'pipe' });
 
   // Create the worktree
   fs.mkdirSync(WORKTREE_DIR, { recursive: true });


### PR DESCRIPTION
## Summary
- **Pipeline ops fixes**: graceful kill for cancel/restart/recover, fresh branch on restart (fixes stale worktree bug), SIGTERM signal handlers in runner, kill orphaned child processes on cancel
- **Editor help drawer**: slide-out reference panel (Guide, Shortcuts, Workflow tabs) accessible via "?" button or Shift+/ — always available for contractors
- **Joyride fixes**: react-joyride v3 API migration (skipBeacon, buttons array), skip/complete permanently disables auto-start, centered first tooltip, snap grid grouped with Grid button
- **Shared process-utils**: extracted gracefulKill() used by restart, cancel, and recover routes
- Revert spawn('claude') — CLI reinstalled globally

## Test plan
- [ ] Pipeline restart creates fresh branch from test (not stale)
- [ ] Cancel pipeline kills both runner and child processes
- [ ] Editor "?" button opens help drawer with 3 tabs
- [ ] Shift+/ keyboard shortcut toggles help drawer
- [ ] Joyride tour shows tooltips (not beacons), Skip button works, doesn't restart after skip
- [ ] Contractor sees Submit step + Help step in hosted mode tour
- [ ] Snap grid dropdown sits next to Grid button
- [ ] `npx vitest run` — 1028 tests pass
- [ ] `npx tsx e2e/help-drawer-test.ts` — 6 Playwright tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)