### PR TITLE
feat: sandbox practice instruments for contractor editor

### DIFF
--- a/src/app/api/hosted/panels/route.ts
+++ b/src/app/api/hosted/panels/route.ts
@@ -1,10 +1,11 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { listDevices } from '@/lib/hosted-storage';
 
-/** GET /api/hosted/panels — list all devices with statuses */
-export async function GET() {
+/** GET /api/hosted/panels — list devices. ?sandbox=true for practice instruments only. */
+export async function GET(request: NextRequest) {
   try {
-    const devices = await listDevices();
+    const sandbox = request.nextUrl.searchParams.get('sandbox') === 'true';
+    const devices = await listDevices({ sandbox });
     return NextResponse.json(devices);
   } catch (err) {
     return NextResponse.json(

--- a/src/app/api/hosted/panels/seed-practice/route.ts
+++ b/src/app/api/hosted/panels/seed-practice/route.ts
@@ -1,0 +1,133 @@
+import { NextResponse } from 'next/server';
+import fs from 'fs';
+import path from 'path';
+import { getDeviceStatus, initDevice, putPhoto } from '@/lib/hosted-storage';
+
+/**
+ * POST /api/hosted/panels/seed-practice
+ *
+ * Idempotently seeds sandbox practice instruments into Vercel Blob.
+ * Clones real manifests + photos so contractors can practice the editor.
+ */
+
+interface PracticeDevice {
+  sandboxId: string;
+  deviceName: string;
+  manufacturer: string;
+  manifestSource: string;      // path to manifest JSON
+  photosSource: string;        // directory with reference photos
+}
+
+const PRACTICE_DEVICES: PracticeDevice[] = [
+  {
+    sandboxId: 'sandbox-fantom-06',
+    deviceName: 'Fantom 06 (Practice)',
+    manufacturer: 'Roland',
+    manifestSource: 'src/data/manifests/fantom-06.json',
+    photosSource: '.pipeline/fantom-06/input/photos',
+  },
+  {
+    sandboxId: 'sandbox-cdj-3000',
+    deviceName: 'CDJ-3000 (Practice)',
+    manufacturer: 'Pioneer DJ',
+    manifestSource: '.pipeline/cdj-3000/manifest-editor.json',
+    photosSource: '.pipeline/cdj-3000/input/photos',
+  },
+];
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => ({}));
+  const force = (body as Record<string, unknown>).force === true;
+  const results: Array<{ deviceId: string; action: string }> = [];
+
+  for (const device of PRACTICE_DEVICES) {
+    // Skip if already seeded (unless force=true to re-seed with updated format)
+    if (!force) {
+      const existing = await getDeviceStatus(device.sandboxId);
+      if (existing) {
+        results.push({ deviceId: device.sandboxId, action: 'already exists' });
+        continue;
+      }
+    }
+
+    // Read manifest from disk
+    const manifestPath = path.resolve(device.manifestSource);
+    if (!fs.existsSync(manifestPath)) {
+      results.push({ deviceId: device.sandboxId, action: `skipped — manifest not found: ${device.manifestSource}` });
+      continue;
+    }
+
+    const raw = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+
+    // Transform production manifest format → editor auto-save format
+    // Production uses editorPosition: { x, y, w, h } nested; editor expects flat x, y, w, h
+    // Production uses editorSections; editor expects sections with childIds
+    const manifest: Record<string, unknown> = {
+      ...raw,
+      deviceId: device.sandboxId,
+      deviceName: device.deviceName,
+      _source: 'editor',
+    };
+
+    // Convert editorSections → sections (with childIds)
+    if (raw.editorSections && !raw.sections) {
+      const controls = Array.isArray(raw.controls) ? raw.controls : [];
+      manifest.sections = raw.editorSections.map((s: any) => ({
+        ...s,
+        childIds: controls
+          .filter((c: any) => {
+            // Assign control to section by checking if control is inside section bounds
+            const pos = c.editorPosition ?? c;
+            const cx = pos.x + (pos.w ?? 0) / 2;
+            const cy = pos.y + (pos.h ?? 0) / 2;
+            return cx >= s.x && cx <= s.x + s.w && cy >= s.y && cy <= s.y + s.h;
+          })
+          .map((c: any) => c.id),
+      }));
+      delete manifest.editorSections;
+    }
+
+    // Flatten editorPosition into controls
+    if (Array.isArray(raw.controls)) {
+      manifest.controls = raw.controls.map((c: any) => {
+        const pos = c.editorPosition ?? {};
+        const { editorPosition, ...rest } = c;
+        return {
+          ...rest,
+          x: pos.x ?? 0,
+          y: pos.y ?? 0,
+          w: pos.w ?? 40,
+          h: pos.h ?? 40,
+          sectionId: rest.sectionId ?? '',
+          locked: rest.locked ?? false,
+          labelPosition: rest.labelPosition ?? 'above',
+        };
+      });
+    }
+
+    // Seed to Blob
+    await initDevice(
+      device.sandboxId,
+      device.deviceName,
+      device.manufacturer,
+      manifest,
+      { isSandbox: true },
+    );
+
+    // Upload photos
+    const photosDir = path.resolve(device.photosSource);
+    if (fs.existsSync(photosDir)) {
+      const photos = fs.readdirSync(photosDir).filter(f => /\.(jpg|jpeg|png|webp)$/i.test(f));
+      for (const photo of photos) {
+        const data = fs.readFileSync(path.join(photosDir, photo));
+        await putPhoto(device.sandboxId, photo, data);
+      }
+      const controlCount = Array.isArray(manifest.controls) ? manifest.controls.length : '?';
+      results.push({ deviceId: device.sandboxId, action: `seeded with ${controlCount} controls, ${photos.length} photos` });
+    } else {
+      results.push({ deviceId: device.sandboxId, action: `seeded (no photos found at ${device.photosSource})` });
+    }
+  }
+
+  return NextResponse.json({ ok: true, results });
+}

--- a/src/app/api/pipeline/[deviceId]/send-to-hosted/route.ts
+++ b/src/app/api/pipeline/[deviceId]/send-to-hosted/route.ts
@@ -39,7 +39,7 @@ export async function POST(
       manifest.deviceName ?? deviceId,
       manifest.manufacturer ?? '',
       manifest,
-      note,
+      { adminNote: note },
     );
 
     // Upload photos

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -51,6 +51,19 @@ export default function EditorListPage() {
           </button>
         </div>
 
+        {/* Practice Editor link */}
+        <Link
+          href="/editor/practice"
+          className="flex items-center gap-3 rounded-lg border border-violet-500/20 bg-violet-900/10 px-5 py-3 mb-4 transition-colors hover:border-violet-500/40 hover:bg-violet-900/20"
+        >
+          <div className="w-2 h-2 rounded-full bg-violet-400" />
+          <div className="flex-1">
+            <p className="text-sm font-medium text-violet-300">Practice Editor</p>
+            <p className="text-[11px] text-gray-500">Learn the tools without affecting real instruments</p>
+          </div>
+          <span className="text-xs text-violet-400">→</span>
+        </Link>
+
         {loading ? (
           <div className="text-gray-500 text-sm">Loading...</div>
         ) : error ? (

--- a/src/app/editor/practice/[deviceId]/page.tsx
+++ b/src/app/editor/practice/[deviceId]/page.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { useParams } from 'next/navigation';
+import Link from 'next/link';
+import PanelEditor from '@/components/panel-editor/PanelEditor';
+
+export default function PracticeEditorPage() {
+  const { deviceId } = useParams<{ deviceId: string }>();
+  if (!deviceId) return null;
+  return (
+    <div className="flex flex-col h-screen">
+      <div className="flex items-center gap-2 h-9 border-b border-gray-800 bg-[#0d0d1a] px-3">
+        <Link href="/editor/practice" className="text-[11px] text-gray-500 hover:text-gray-300 transition-colors">
+          ← Practice Instruments
+        </Link>
+        <span className="rounded bg-violet-600/20 border border-violet-500/30 px-2 py-0.5 text-[10px] font-medium text-violet-400">
+          Practice Mode
+        </span>
+      </div>
+      <div className="flex-1 overflow-hidden">
+        <PanelEditor deviceId={deviceId} isSandbox />
+      </div>
+    </div>
+  );
+}

--- a/src/app/editor/practice/page.tsx
+++ b/src/app/editor/practice/page.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+
+interface DeviceSummary {
+  deviceId: string;
+  deviceName: string;
+  manufacturer: string;
+}
+
+export default function PracticeListPage() {
+  const [devices, setDevices] = useState<DeviceSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [seeding, setSeeding] = useState(false);
+
+  useEffect(() => {
+    loadDevices();
+  }, []);
+
+  async function loadDevices() {
+    try {
+      const res = await fetch('/api/hosted/panels?sandbox=true');
+      const data = await res.json();
+      const list = Array.isArray(data) ? data : [];
+
+      if (list.length === 0 && !seeding) {
+        // Auto-seed practice instruments on first visit
+        setSeeding(true);
+        await fetch('/api/hosted/panels/seed-practice', { method: 'POST' });
+        // Re-fetch after seeding
+        const res2 = await fetch('/api/hosted/panels?sandbox=true');
+        const data2 = await res2.json();
+        setDevices(Array.isArray(data2) ? data2 : []);
+        setSeeding(false);
+      } else {
+        setDevices(list);
+      }
+    } catch {
+      // Seeding may fail on Vercel (no local files) — show empty state
+      setDevices([]);
+    }
+    setLoading(false);
+  }
+
+  return (
+    <div className="min-h-screen bg-[#0d0d1a] p-8">
+      <div className="max-w-2xl mx-auto">
+        <div className="mb-6">
+          <Link href="/editor" className="text-xs text-gray-500 hover:text-gray-300 transition-colors">
+            ← Back to instruments
+          </Link>
+          <h1 className="text-2xl font-bold text-gray-200 mt-3 mb-1">Practice Editor</h1>
+          <p className="text-sm text-gray-500">Learn the tools without affecting real instruments</p>
+        </div>
+
+        {loading || seeding ? (
+          <div className="text-gray-500 text-sm">
+            {seeding ? 'Setting up practice instruments...' : 'Loading...'}
+          </div>
+        ) : devices.length === 0 ? (
+          <div className="rounded-lg border border-gray-800 bg-[#111122] p-8 text-center">
+            <p className="text-gray-400">No practice instruments available</p>
+            <p className="text-sm text-gray-600 mt-1">Practice instruments are set up by the admin</p>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {devices.map((d) => (
+              <div
+                key={d.deviceId}
+                className="rounded-lg border border-gray-800 bg-[#111122] px-5 py-4 transition-colors hover:border-gray-700"
+              >
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-3">
+                    <div className="w-2 h-2 rounded-full bg-violet-400" />
+                    <div>
+                      <h2 className="text-sm font-semibold text-gray-200">
+                        {d.manufacturer} {d.deviceName}
+                      </h2>
+                      <p className="text-[11px] text-gray-500 mt-0.5">Practice — your changes won't affect real instruments</p>
+                    </div>
+                  </div>
+                  <Link
+                    href={`/editor/practice/${d.deviceId}`}
+                    className="rounded bg-violet-600 px-4 py-2 text-sm font-medium text-white hover:bg-violet-500 transition-colors"
+                  >
+                    Edit →
+                  </Link>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/panel-editor/EditorToolbar.tsx
+++ b/src/components/panel-editor/EditorToolbar.tsx
@@ -97,6 +97,7 @@ interface EditorToolbarProps {
   onReportIssue?: () => void;
   onRestoreVersion?: () => void;
   onToggleHelp?: () => void;
+  isSandbox?: boolean;
 }
 
 export default function EditorToolbar({
@@ -109,6 +110,7 @@ export default function EditorToolbar({
   onReportIssue,
   onRestoreVersion,
   onToggleHelp,
+  isSandbox,
 }: EditorToolbarProps) {
   const manufacturer = useEditorStore((s) => s.manufacturer);
   const deviceName = useEditorStore((s) => s.deviceName);
@@ -411,7 +413,11 @@ export default function EditorToolbar({
           />
         </div>
 
-        {isHosted ? (
+        {isHosted && isSandbox ? (
+          <span className="flex h-7 items-center px-3 text-[10px] font-medium text-violet-400 border border-violet-500/30 bg-violet-600/15 rounded whitespace-nowrap">
+            Practice Mode
+          </span>
+        ) : isHosted ? (
           <div data-tutorial="submit">
             {(typeof window !== 'undefined' && (window as any).__submittedForReview) ? (
               <span className="flex h-7 items-center px-3 text-[10px] font-medium text-green-400 border border-green-700 bg-green-700/20 rounded whitespace-nowrap">

--- a/src/components/panel-editor/EditorToolbar.tsx
+++ b/src/components/panel-editor/EditorToolbar.tsx
@@ -324,7 +324,7 @@ export default function EditorToolbar({
       >?</button>
 
       {/* History + Report — local only */}
-      {!isHosted && (
+      {!isHosted && !isSandbox && (
         <>
           <VersionHistoryDropdown deviceId={deviceId} onRestore={onRestoreVersion} />
 
@@ -413,7 +413,7 @@ export default function EditorToolbar({
           />
         </div>
 
-        {isHosted && isSandbox ? (
+        {isSandbox ? (
           <span className="flex h-7 items-center px-3 text-[10px] font-medium text-violet-400 border border-violet-500/30 bg-violet-600/15 rounded whitespace-nowrap">
             Practice Mode
           </span>

--- a/src/components/panel-editor/EditorWorkspace.tsx
+++ b/src/components/panel-editor/EditorWorkspace.tsx
@@ -22,7 +22,8 @@ export default function EditorWorkspace({ deviceId, readOnly }: EditorWorkspaceP
     let cancelled = false;
     async function fetchPhoto() {
       try {
-        const res = await fetch(`${isHosted ? '/api/hosted/panels' : '/api/pipeline'}/${deviceId}/photos`);
+        const useHostedApi = isHosted || deviceId.startsWith('sandbox-');
+        const res = await fetch(`${useHostedApi ? '/api/hosted/panels' : '/api/pipeline'}/${deviceId}/photos`);
         if (!res.ok) return;
         const data = await res.json();
         const photos = data.photos ?? data;

--- a/src/components/panel-editor/EditorWorkspace.tsx
+++ b/src/components/panel-editor/EditorWorkspace.tsx
@@ -33,7 +33,7 @@ export default function EditorWorkspace({ deviceId, readOnly }: EditorWorkspaceP
           );
           const chosen = topView ?? photos[0];
           setPhotoUrl(
-            isHosted
+            useHostedApi
               ? chosen.url  // Blob URLs are direct
               : `/api/pipeline/${deviceId}/photos?file=${encodeURIComponent(chosen.name)}`
           );

--- a/src/components/panel-editor/PanelEditor.tsx
+++ b/src/components/panel-editor/PanelEditor.tsx
@@ -19,10 +19,11 @@ import { cleanupGeometry } from '@/lib/layout-inference';
 
 interface PanelEditorProps {
   deviceId: string;
+  isSandbox?: boolean;
 }
 
 /** Inner shell rendered after manifest is loaded. Hooks run unconditionally here. */
-function EditorShell({ deviceId, onRestoreVersion, adminNote }: { deviceId: string; onRestoreVersion?: () => void; adminNote?: string | null }) {
+function EditorShell({ deviceId, onRestoreVersion, adminNote, isSandbox }: { deviceId: string; onRestoreVersion?: () => void; adminNote?: string | null; isSandbox?: boolean }) {
   useEditorKeyboard();
   useAutoSave(deviceId);
 
@@ -151,6 +152,7 @@ function EditorShell({ deviceId, onRestoreVersion, adminNote }: { deviceId: stri
         onReportIssue={() => setShowIssueModal(true)}
         onRestoreVersion={onRestoreVersion}
         onToggleHelp={() => setShowHelp((s) => !s)}
+        isSandbox={isSandbox}
       />
 
       {/* Codegen error banner — local only */}
@@ -239,7 +241,7 @@ function EditorShell({ deviceId, onRestoreVersion, adminNote }: { deviceId: stri
   );
 }
 
-export default function PanelEditor({ deviceId }: PanelEditorProps) {
+export default function PanelEditor({ deviceId, isSandbox }: PanelEditorProps) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [reloadKey, setReloadKey] = useState(0);
@@ -270,7 +272,8 @@ export default function PanelEditor({ deviceId }: PanelEditorProps) {
 
     async function fetchManifest() {
       try {
-        const res = await fetch(`${isHosted ? '/api/hosted/panels' : '/api/pipeline'}/${deviceId}${isHosted ? '' : '/manifest'}`);
+        const useHostedApi = isHosted || isSandbox;
+        const res = await fetch(`${useHostedApi ? '/api/hosted/panels' : '/api/pipeline'}/${deviceId}${useHostedApi ? '' : '/manifest'}`);
         if (!res.ok) {
           const body = await res.json().catch(() => ({}));
           throw new Error(
@@ -279,16 +282,18 @@ export default function PanelEditor({ deviceId }: PanelEditorProps) {
         }
         const data = await res.json();
         if (!cancelled) {
-          if ((data._source === 'editor' || data._source === 'hosted') && data.sections && data.controls) {
+          // Accept both 'sections' (editor auto-save format) and 'editorSections' (production manifest format)
+          const rawSections = data.sections ?? data.editorSections;
+          if ((data._source === 'editor' || data._source === 'hosted') && rawSections && data.controls) {
             // Restore previously saved editor state (flat sections/controls)
             // API normalizes to arrays — convert back to Record<id, Def> if needed
-            const sections = Array.isArray(data.sections)
-              ? Object.fromEntries(data.sections.map((s: any) => [s.id, {
+            const sections = Array.isArray(rawSections)
+              ? Object.fromEntries(rawSections.map((s: any) => [s.id, {
                   ...s,
                   // Normalize: manifest uses 'controls', editor uses 'childIds'
                   childIds: s.childIds ?? s.controls ?? [],
                 }]))
-              : data.sections;
+              : rawSections;
             const controls = Array.isArray(data.controls)
               ? Object.fromEntries(data.controls.map((c: any) => [c.id, c]))
               : data.controls;
@@ -386,5 +391,5 @@ export default function PanelEditor({ deviceId }: PanelEditorProps) {
     );
   }
 
-  return <EditorShell deviceId={deviceId} onRestoreVersion={forceReload} adminNote={adminNote} />;
+  return <EditorShell deviceId={deviceId} onRestoreVersion={forceReload} adminNote={adminNote} isSandbox={isSandbox} />;
 }

--- a/src/components/panel-editor/PhotoOverlay.tsx
+++ b/src/components/panel-editor/PhotoOverlay.tsx
@@ -2,11 +2,12 @@
 
 import { useEffect, useState } from 'react';
 import { useEditorStore } from './store';
+import { isHosted } from '@/lib/env';
 
 /**
  * Renders the first hardware reference photo behind the canvas content.
  * Reads deviceId from the editor store.
- * Fetches the photo list from the pipeline API.
+ * Fetches the photo list from the appropriate API (pipeline or hosted).
  */
 export default function PhotoOverlay() {
   const showPhoto = useEditorStore((s) => s.showPhoto);
@@ -26,10 +27,11 @@ export default function PhotoOverlay() {
 
     async function fetchPhotos() {
       try {
-        const res = await fetch(`/api/pipeline/${deviceId}/photos`);
+        const useHostedApi = isHosted || deviceId.startsWith('sandbox-');
+        const res = await fetch(`${useHostedApi ? '/api/hosted/panels' : '/api/pipeline'}/${deviceId}/photos`);
         if (!res.ok) return;
         const data = await res.json();
-        // API returns { photos: [{ name, path, size }] }
+        // API returns { photos: [{ name, path, size }] } or [{ name, url }]
         const photos = data.photos ?? data;
         if (!cancelled && Array.isArray(photos) && photos.length > 0) {
           // Prefer the top-view photo if available, otherwise first photo
@@ -37,9 +39,11 @@ export default function PhotoOverlay() {
             p.name.toLowerCase().includes('top-view') || p.name.toLowerCase().includes('top_view')
           );
           const chosen = topView ?? photos[0];
-          // API serves photos via ?file= query param, not subpath
-          const url = `/api/pipeline/${deviceId}/photos?file=${encodeURIComponent(chosen.name)}`;
-          setPhotoUrl(url);
+          setPhotoUrl(
+            useHostedApi
+              ? chosen.url  // Blob URLs are direct
+              : `/api/pipeline/${deviceId}/photos?file=${encodeURIComponent(chosen.name)}`
+          );
         }
       } catch {
         // Silently ignore — photo overlay is optional

--- a/src/components/panel-editor/hooks/useAutoSave.ts
+++ b/src/components/panel-editor/hooks/useAutoSave.ts
@@ -84,7 +84,8 @@ export function useAutoSave(deviceId: string) {
           if (isHosted && useEditorStore.getState().previewMode) return;
 
           const { sections, controls, editorLabels, controlGroups, canvasWidth, canvasHeight, _manifestVersion, controlScale, zoom, cleanupGap, panelScale, keyboard } = useEditorStore.getState();
-          fetch(`${isHosted ? '/api/hosted/panels' : '/api/pipeline'}/${deviceId}${isHosted ? '' : '/manifest'}`, {
+          const useHostedApi = isHosted || deviceId.startsWith('sandbox-');
+          fetch(`${useHostedApi ? '/api/hosted/panels' : '/api/pipeline'}/${deviceId}${useHostedApi ? '' : '/manifest'}`, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ sections, controls, editorLabels, controlGroups, canvasWidth, canvasHeight, _manifestVersion, controlScale, zoom, cleanupGap, panelScale, keyboard }),

--- a/src/lib/hosted-storage.ts
+++ b/src/lib/hosted-storage.ts
@@ -29,6 +29,7 @@ export interface DeviceStatusData {
   status: DeviceStatus;
   adminNote?: string;       // admin → contractor (feedback, instructions)
   contractorNote?: string;  // contractor → admin (submission notes)
+  isSandbox?: boolean;      // practice instrument — no submit, hidden from admin
   updatedAt: string;
 }
 
@@ -40,6 +41,7 @@ export interface DeviceSummary {
   updatedAt: string;
   adminNote?: string;
   contractorNote?: string;
+  isSandbox?: boolean;
 }
 
 // ─── Valid state transitions ────────────────────────────────────────────────
@@ -116,7 +118,7 @@ export async function putDeviceManifest(deviceId: string, manifest: Record<strin
 
 // ─── List operations ────────────────────────────────────────────────────────
 
-export async function listDevices(): Promise<DeviceSummary[]> {
+export async function listDevices(opts?: { sandbox?: boolean }): Promise<DeviceSummary[]> {
   try {
     const { blobs } = await list({ prefix: `${PREFIX}/` });
     const statusBlobs = blobs.filter(b => b.pathname.endsWith('/status.json'));
@@ -134,6 +136,7 @@ export async function listDevices(): Promise<DeviceSummary[]> {
             updatedAt: data.updatedAt,
             adminNote: data.adminNote,
             contractorNote: data.contractorNote,
+            isSandbox: data.isSandbox,
           } as DeviceSummary;
         } catch {
           return null;
@@ -141,7 +144,11 @@ export async function listDevices(): Promise<DeviceSummary[]> {
       })
     );
 
-    return results.filter(Boolean) as DeviceSummary[];
+    const all = results.filter(Boolean) as DeviceSummary[];
+
+    // Filter by sandbox flag: true = only sandbox, false/undefined = exclude sandbox
+    if (opts?.sandbox === true) return all.filter(d => d.isSandbox);
+    return all.filter(d => !d.isSandbox);
   } catch {
     return [];
   }
@@ -177,14 +184,15 @@ export async function initDevice(
   deviceName: string,
   manufacturer: string,
   manifest: Record<string, unknown>,
-  adminNote?: string,
+  opts?: { adminNote?: string; isSandbox?: boolean },
 ): Promise<void> {
   await putDeviceStatus(deviceId, {
     deviceId,
     deviceName,
     manufacturer,
     status: 'ready',
-    adminNote,
+    adminNote: opts?.adminNote,
+    isSandbox: opts?.isSandbox,
     updatedAt: new Date().toISOString(),
   });
   await putDeviceManifest(deviceId, manifest);


### PR DESCRIPTION
## Summary
- New `/editor/practice` page with sandbox copies of Fantom-06 and CDJ-3000
- Full editor experience (drag, align, photo overlay, snap grid, undo) — no Submit button
- Sandbox devices stored in Vercel Blob under `sandbox-` prefixed IDs
- Auto-seed on first visit via `POST /api/hosted/panels/seed-practice`
- Seed transforms production manifest format to editor format
- Photo overlay works in both side-by-side and overlay modes
- "Practice Mode" badge replaces Submit/Export button
- Version history, report issue hidden for sandbox (no pipeline state)
- All pipeline API calls correctly routed for sandbox devices
- Zero impact on real instrument editor flow

## Test plan
- [ ] `/editor` shows "Practice Editor" link
- [ ] `/editor/practice` lists sandbox instruments after seeding
- [ ] Editor works fully on sandbox (drag, align, photo overlay, undo)
- [ ] No Submit button on sandbox editor — shows "Practice Mode"
- [ ] Photo overlay works in both modes (side-by-side + overlay)
- [ ] Admin dashboard does NOT show sandbox devices
- [ ] Real editor still works — version history, export, submit all functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)