### PR TITLE
fix: sandbox canvas dimensions + proper device names

### DIFF
--- a/src/app/api/hosted/panels/seed-practice/route.ts
+++ b/src/app/api/hosted/panels/seed-practice/route.ts
@@ -67,6 +67,10 @@ export async function POST(request: Request) {
       deviceId: device.sandboxId,
       deviceName: device.deviceName,
       _source: 'editor',
+      // Map panelWidth/panelHeight to canvasWidth/canvasHeight so the editor
+      // and photo overlay render at the correct dimensions
+      canvasWidth: raw.canvasWidth ?? raw.panelWidth ?? 1200,
+      canvasHeight: raw.canvasHeight ?? raw.panelHeight ?? 800,
     };
 
     // Convert editorSections → sections (with childIds)

--- a/src/app/api/pipeline/[deviceId]/send-to-hosted/route.ts
+++ b/src/app/api/pipeline/[deviceId]/send-to-hosted/route.ts
@@ -26,6 +26,19 @@ export async function POST(
   try {
     const manifest = JSON.parse(fs.readFileSync(editorPath, 'utf-8'));
 
+    // Read pipeline state for proper device name/manufacturer
+    // (manifest may only have the slug as deviceName)
+    let deviceName = manifest.deviceName ?? deviceId;
+    let manufacturer = manifest.manufacturer ?? '';
+    const statePath = path.join(pipelineDir, 'state.json');
+    if (fs.existsSync(statePath)) {
+      try {
+        const state = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
+        if (state.deviceName) deviceName = state.deviceName;
+        if (state.manufacturer) manufacturer = state.manufacturer;
+      } catch { /* ignore parse errors — fall back to manifest values */ }
+    }
+
     // Read optional note from request body
     let note: string | undefined;
     try {
@@ -36,8 +49,8 @@ export async function POST(
     // Write both blobs (status.json + manifest.json)
     await initDevice(
       deviceId,
-      manifest.deviceName ?? deviceId,
-      manifest.manufacturer ?? '',
+      deviceName,
+      manufacturer,
       manifest,
       { adminNote: note },
     );


### PR DESCRIPTION
## Summary
- Seed endpoint now includes `canvasWidth`/`canvasHeight` from manifest's `panelWidth`/`panelHeight` — fixes photo overlay rendering at wrong size on Vercel
- Send-to-hosted reads device name from pipeline `state.json` instead of manifest slug — contractor sees "Roland Fantom 06" instead of "fantom-06"

## Test plan
- [ ] Practice Fantom-06 photo overlay renders behind controls (not below)
- [ ] Next "Send to Contractor" shows proper instrument name on contractor list
- [ ] Real editor unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)