### PR TITLE
fix: audit results persist — no auto-resolve, visible after refresh

### DIFF
--- a/src/app/api/pipeline/[deviceId]/audit-controls/route.ts
+++ b/src/app/api/pipeline/[deviceId]/audit-controls/route.ts
@@ -128,9 +128,9 @@ Rules:
         const issues = await getDeviceIssues(deviceId);
         const updated = issues.map(i => i.id === issueId ? {
           ...i,
-          status: (findings.length > 0 ? 'open' : 'resolved') as 'open' | 'resolved',
+          status: 'open' as const,
           findings: findings.length > 0 ? findings : undefined,
-          resolution: findings.length === 0 ? 'Audit found no missing controls' : undefined,
+          resolution: findings.length === 0 ? 'Audit completed — no missing controls found' : undefined,
         } : i);
         await putDeviceIssues(deviceId, updated);
       } catch { /* best effort */ }

--- a/src/components/admin/ContractorSubmissions.tsx
+++ b/src/components/admin/ContractorSubmissions.tsx
@@ -422,10 +422,10 @@ export default function ContractorSubmissions() {
                               </div>
                             )}
 
-                            {/* Audit result message */}
-                            {auditResult[issue.id] && !auditFindings[issue.id]?.length && !issue.findings?.length && auditRunning !== issue.id && issue.status !== 'investigating' && (
-                              <p className={`mt-2 text-[11px] ${auditResult[issue.id].startsWith('✓') ? 'text-green-400' : auditResult[issue.id].startsWith('Error') ? 'text-red-400' : 'text-gray-400'}`}>
-                                {auditResult[issue.id]}
+                            {/* Audit result message (local state or Blob resolution) */}
+                            {!auditFindings[issue.id]?.length && !issue.findings?.length && auditRunning !== issue.id && issue.status !== 'investigating' && (auditResult[issue.id] || issue.resolution) && (
+                              <p className={`mt-2 text-[11px] ${(auditResult[issue.id] ?? '').startsWith('✓') ? 'text-green-400' : (auditResult[issue.id] ?? '').startsWith('Error') ? 'text-red-400' : 'text-gray-400'}`}>
+                                {auditResult[issue.id] || issue.resolution}
                               </p>
                             )}
 

--- a/src/components/admin/IssuesPanel.tsx
+++ b/src/components/admin/IssuesPanel.tsx
@@ -197,10 +197,10 @@ export default function IssuesPanel({ deviceId }: IssuesPanelProps) {
                 </div>
               )}
 
-              {/* Result message */}
-              {auditResult[issue.id] && !auditFindings[issue.id]?.length && auditRunning !== issue.id && (
-                <p className={`text-[10px] mb-2 ${auditResult[issue.id].startsWith('✓') ? 'text-green-400' : auditResult[issue.id].startsWith('Error') ? 'text-red-400' : 'text-gray-400'}`}>
-                  {auditResult[issue.id]}
+              {/* Result message (local state or Blob resolution) */}
+              {!auditFindings[issue.id]?.length && !issue.findings?.length && auditRunning !== issue.id && issue.status !== 'investigating' && (auditResult[issue.id] || issue.resolution) && (
+                <p className={`text-[10px] mb-2 ${(auditResult[issue.id] ?? '').startsWith('✓') ? 'text-green-400' : (auditResult[issue.id] ?? '').startsWith('Error') ? 'text-red-400' : 'text-gray-400'}`}>
+                  {auditResult[issue.id] || issue.resolution}
                 </p>
               )}
 


### PR DESCRIPTION
## Summary
- Issues no longer auto-resolve when audit finds no missing controls — stays open with resolution message so admin can see the result and dismiss manually
- Both IssuesPanel and ContractorSubmissions display `issue.resolution` from Blob as fallback when local state is cleared (page refresh, navigation)
- All audit states persist in Blob: investigating, findings, resolution

## State flow
| Action | Status | What admin sees |
|--------|--------|----------------|
| Contractor files issue | open | Run Audit + Dismiss buttons |
| Admin runs audit | investigating | Spinner on both panels |
| Agent finds controls | open (with findings) | Green card + Add & Send |
| Agent finds nothing | open (with resolution) | "No missing controls found" + Dismiss |
| Admin adds & sends | resolved | Disappears |
| Admin dismisses | resolved | Disappears |

## Test plan
- [ ] Run audit that finds nothing → result message visible
- [ ] Refresh page → result message still visible
- [ ] Check both IssuesPanel and ContractorSubmissions show same state

🤖 Generated with [Claude Code](https://claude.com/claude-code)