### PR TITLE
feat: hide sections, pad font size, gatekeeper scoring, editor-ready escalation

### DIFF
--- a/scripts/pipeline-runner.ts
+++ b/scripts/pipeline-runner.ts
@@ -1182,7 +1182,7 @@ async function doPhase0LayoutEngine(state: PipelineState) {
     );
     if (!editorPending) {
       // Re-create escalation (shouldn't happen, but defensive)
-      createEscalation(state, 'agent-failure',
+      createEscalation(state, 'editor-ready',
         `Pipeline ready for editor. Click "Send to Contractor" to upload the manifest for the contractor to edit. ` +
         `Resume the pipeline after the panel is approved to start QA.\n` +
         `Manifest: .pipeline/${deviceId}/manifest.json\n` +
@@ -1271,7 +1271,7 @@ async function doPhase0LayoutEngine(state: PipelineState) {
       completePhase(state, 'phase-0-layout-engine', 10, true);
       // Pause for editor — the contractor positions controls via the hosted editor.
       // Use "Send to Contractor" on the pipeline detail page to upload to Blob.
-      createEscalation(state, 'agent-failure',
+      createEscalation(state, 'editor-ready',
         `Pipeline ready for editor. Click "Send to Contractor" to upload the manifest for the contractor to edit. ` +
         `Resume the pipeline after the panel is approved to start QA.\n` +
         `Manifest: .pipeline/${deviceId}/manifest.json\n` +

--- a/src/components/admin/EscalationBanner.tsx
+++ b/src/components/admin/EscalationBanner.tsx
@@ -86,6 +86,13 @@ const ESCALATION_CONFIG: Record<
       { label: 'Cancel', resolution: 'cancel', variant: 'danger' },
     ],
   },
+  'editor-ready': {
+    bg: 'rgba(34, 197, 94, 0.1)',
+    border: '#22c55e',
+    buttons: [
+      { label: 'Send to Contractor', resolution: 'send-to-contractor', variant: 'primary' },
+    ],
+  },
 };
 
 const BUTTON_STYLES: Record<string, { bg: string; text: string; hover: string }> = {

--- a/src/components/controls/PadButton.tsx
+++ b/src/components/controls/PadButton.tsx
@@ -11,6 +11,7 @@ interface PadButtonProps {
   onClick?: () => void;
   width?: number;
   height?: number;
+  labelFontSize?: number;
 }
 
 const highlightAnimation = {
@@ -37,6 +38,7 @@ export default function PadButton({
   onClick,
   width = 64,
   height = 64,
+  labelFontSize,
 }: PadButtonProps) {
   return (
       <motion.button
@@ -70,7 +72,10 @@ export default function PadButton({
               : 'radial-gradient(circle at 40% 35%, rgba(255,255,255,0.06) 0%, transparent 60%)',
           }}
         />
-        <span className="absolute bottom-1.5 right-2 text-[11px] font-bold text-gray-400 z-10">
+        <span
+          className="absolute bottom-1.5 right-2 font-bold text-gray-400 z-10"
+          style={{ fontSize: labelFontSize ?? 11 }}
+        >
           {label}
         </span>
       </motion.button>

--- a/src/components/controls/PanelRenderer.tsx
+++ b/src/components/controls/PanelRenderer.tsx
@@ -40,6 +40,7 @@ interface ManifestControl {
   positions?: number;
   positionLabels?: string[];
   rotation?: number;
+  labelFontSize?: number;
   editorPosition?: { x: number; y: number; w: number; h: number };
 }
 
@@ -306,7 +307,8 @@ function renderControl(
           <PadButton id={control.id}
             label={control.labelPosition === 'on-button' ? control.label : ''}
             highlighted={highlighted} active={active}
-            width={w} height={h} onClick={onClick} />
+            width={w} height={h} onClick={onClick}
+            labelFontSize={control.labelFontSize} />
         </div>
       );
     case 'encoder':

--- a/src/components/controls/PanelRenderer.tsx
+++ b/src/components/controls/PanelRenderer.tsx
@@ -59,6 +59,7 @@ interface ManifestLabel {
 interface ManifestSection {
   id: string;
   headerLabel?: string;
+  hidden?: boolean;
   x: number;
   y: number;
   w: number;
@@ -374,7 +375,7 @@ export default function PanelRenderer({
       keyboard={manifest.keyboard}
     >
       {/* Section backgrounds */}
-      {(manifest.editorSections ?? []).map((s) => (
+      {(manifest.editorSections ?? []).filter((s) => !s.hidden).map((s) => (
         <SectionContainer key={s.id} id={s.id}
           x={s.x} y={s.y} w={s.w} h={s.h}
           headerLabel={s.headerLabel} />

--- a/src/components/panel-editor/ControlNode.tsx
+++ b/src/components/panel-editor/ControlNode.tsx
@@ -466,6 +466,7 @@ function renderControl(control: ControlDef, isSelected: boolean, allControls: Re
             highlighted={isSelected}
             width={visW}
             height={visH}
+            labelFontSize={control.labelFontSize}
           />
         </div>
       );

--- a/src/components/panel-editor/PanCanvas.tsx
+++ b/src/components/panel-editor/PanCanvas.tsx
@@ -31,6 +31,7 @@ function storeToManifest(state: ReturnType<typeof useEditorStore.getState>): Pan
     editorSections: sections.map((s) => ({
       id: s.id,
       headerLabel: s.headerLabel ?? undefined,
+      hidden: s.hidden,
       x: s.x,
       y: s.y,
       w: s.w,

--- a/src/components/panel-editor/PropertiesPanel/index.tsx
+++ b/src/components/panel-editor/PropertiesPanel/index.tsx
@@ -178,6 +178,26 @@ function SectionProperties({ section }: { section: SectionDef }) {
         )}
       </div>
 
+      {/* Hide section frame in preview/production */}
+      <div className="flex items-center justify-between">
+        <label className="text-[10px] uppercase tracking-wide text-gray-500">
+          Hide Frame
+        </label>
+        <button
+          onClick={() => {
+            pushSnapshot();
+            useEditorStore.getState().updateSection(section.id, { hidden: !section.hidden });
+          }}
+          className={`text-[9px] px-1.5 py-0.5 rounded transition-colors ${
+            section.hidden
+              ? 'bg-amber-600/30 text-amber-300 border border-amber-600'
+              : 'bg-gray-800 text-gray-500 border border-gray-700 hover:text-gray-300'
+          }`}
+        >
+          {section.hidden ? 'Hidden' : 'Visible'}
+        </button>
+      </div>
+
       {/* Divider */}
       <div className="h-px bg-gray-800" />
 

--- a/src/components/panel-editor/PropertiesPanel/index.tsx
+++ b/src/components/panel-editor/PropertiesPanel/index.tsx
@@ -664,6 +664,7 @@ function MultiControlProperties({ controls }: { controls: ControlDef[] }) {
         label={labelMixed ? '' : labels[0]}
         labelPosition={positionMixed ? 'below' : positions[0]}
         secondaryLabel={secondaryMixed ? undefined : secondaryLabels[0]}
+        labelFontSize={controls[0]?.labelFontSize}
         labelMixed={labelMixed}
         positionMixed={positionMixed}
         secondaryMixed={secondaryMixed}
@@ -672,6 +673,7 @@ function MultiControlProperties({ controls }: { controls: ControlDef[] }) {
         onLabelChange={handleLabelChange}
         onPositionChange={handlePositionChange}
         onSecondaryLabelChange={handleSecondaryLabelChange}
+        onFontSizeChange={(val) => { pushSnapshot(); updateControlProp(ids, 'labelFontSize', val); }}
       />
 
       <div className="h-px bg-gray-800" />

--- a/src/components/panel-editor/store/manifestSlice.ts
+++ b/src/components/panel-editor/store/manifestSlice.ts
@@ -144,6 +144,7 @@ export interface SectionDef {
   gridRows?: number;
   widthPercent?: number;
   complexity?: string;
+  hidden?: boolean; // Hide section frame in preview/production — controls still render
 }
 
 // ─── Slice interface ────────────────────────────────────────────────────────
@@ -181,6 +182,7 @@ export interface ManifestSlice {
   resizeSection: (id: string, w: number, h: number) => void;
   setSectionPosition: (id: string, x: number, y: number) => void;
   setSectionLabel: (id: string, label: string | null) => void;
+  updateSection: (id: string, updates: Partial<SectionDef>) => void;
   moveSelectedControls: (dx: number, dy: number) => void;
   updateControlProp: (ids: string[], field: string, value: unknown) => void;
   duplicateSelected: () => void;
@@ -902,6 +904,17 @@ export const createManifestSlice: StateCreator<
       sections: {
         ...s.sections,
         [id]: { ...section, headerLabel: label },
+      },
+    }));
+  },
+
+  updateSection: (id, updates) => {
+    const section = get().sections[id];
+    if (!section) return;
+    set((s) => ({
+      sections: {
+        ...s.sections,
+        [id]: { ...section, ...updates },
       },
     }));
   },

--- a/src/lib/pipeline/checkpoint-validators.ts
+++ b/src/lib/pipeline/checkpoint-validators.ts
@@ -818,6 +818,20 @@ export function validateManifestCompleteness(
       c.shape = 'square';
     }
 
+    // Rule 16: Missing shape on any remaining type → default shape
+    if (!c.shape) {
+      const defaultShape = (['knob', 'encoder', 'wheel', 'dial'].includes(c.type)) ? 'circle' : 'rectangle';
+      autoFixes.push({ controlId: c.id, field: 'shape', from: c.shape, to: defaultShape, rule: 'default-shape-fallback' });
+      c.shape = defaultShape;
+    }
+
+    // Rule 17: Missing labelDisplay → default based on type
+    if (!c.labelDisplay) {
+      const defaultDisplay = c.type === 'led' ? 'below' : c.type === 'port' || c.type === 'slot' ? 'hidden' : 'above';
+      autoFixes.push({ controlId: c.id, field: 'labelDisplay', from: c.labelDisplay, to: defaultDisplay, rule: 'default-labelDisplay-fallback' });
+      c.labelDisplay = defaultDisplay;
+    }
+
     // Rule 6: Missing orientation on fader/slider → orientation = "vertical"
     if ((c.type === 'fader' || c.type === 'slider') && !c.orientation) {
       autoFixes.push({ controlId: c.id, field: 'orientation', from: c.orientation, to: 'vertical', rule: 'default-orientation-fader-slider' });
@@ -942,15 +956,20 @@ export function validateManifestCompleteness(
   for (const c of controls) {
     if (duplicateIds.has(c.id)) continue; // Already penalized
 
-    // shape, sizeClass, labelDisplay — auto-fixed to defaults, don't penalize
+    // shape, sizeClass, labelDisplay — scored AFTER auto-fixes have run.
+    // Only penalize if still missing after auto-fix (e.g., button without shape
+    // has no auto-fix rule, so it's a real gap from the gatekeeper).
     if (!c.shape) {
-      missing.push({ controlId: c.id, field: 'shape', severity: 'minor' });
+      score -= 0.5;
+      missing.push({ controlId: c.id, field: 'shape', severity: 'major' });
     }
     if (!c.sizeClass) {
-      missing.push({ controlId: c.id, field: 'sizeClass', severity: 'minor' });
+      score -= 0.5;
+      missing.push({ controlId: c.id, field: 'sizeClass', severity: 'major' });
     }
     if (!c.labelDisplay) {
-      missing.push({ controlId: c.id, field: 'labelDisplay', severity: 'minor' });
+      score -= 0.5;
+      missing.push({ controlId: c.id, field: 'labelDisplay', severity: 'major' });
     }
 
     // buttonStyle on buttons

--- a/src/lib/pipeline/checkpoint-validators.ts
+++ b/src/lib/pipeline/checkpoint-validators.ts
@@ -377,18 +377,12 @@ export function validateGatekeeperManifest(manifestJson: string): ValidationResu
     score -= 1.0;
   }
 
-  // 6. Controls must have spatialNeighbors
+  // 6. Controls should have spatialNeighbors (enrichment — can be inferred from blueprint)
   const missingNeighbors = controls.filter(c => !c.spatialNeighbors);
-  if (missingNeighbors.length > 0) {
-    errors.push(`${missingNeighbors.length} controls missing spatialNeighbors`);
-    score -= 0.5;
-  }
+  // Not a hard error — layout engine computes neighbors from diagram parser centroids
 
-  // 7. Density targets
-  if (!manifest.densityTargets) {
-    errors.push('Missing densityTargets');
-    score -= 0.5;
-  }
+  // 7. Density targets (enrichment — layout engine has defaults)
+  // Not a hard error — layout engine uses sensible defaults when missing
 
   // 8. heightSplits must be 0-1 range (not integers like 30, 65) — auto-correct
   for (const s of sections) {
@@ -407,11 +401,8 @@ export function validateGatekeeperManifest(manifestJson: string): ValidationResu
   }
 
   // 9. panelBoundingBox — sections should have global positioning data
-  const missingBBox = sections.filter(s => !s.panelBoundingBox);
-  if (missingBBox.length > 0) {
-    errors.push(`${missingBBox.length} sections missing panelBoundingBox: ${missingBBox.slice(0, 3).map(s => s.id).join(', ')}`);
-    score -= 0.5;
-  }
+  // Enrichment field — diagram parser provides this, gatekeeper copies it.
+  // If missing, layout engine uses parser blueprint directly. Not a hard error.
 
   // 10. Validate keyboard field
   if (manifest.keyboard !== undefined && manifest.keyboard !== null) {
@@ -457,17 +448,6 @@ export function validateGatekeeperManifest(manifestJson: string): ValidationResu
     }
     if (missingLabelDisplay > 0) {
       autoFixInfo.push(`${missingLabelDisplay}/${totalControls} controls missing labelDisplay (auto-fixed)`);
-    }
-
-    // Check for heightSplits auto-corrections
-    for (const s of sections) {
-      const splits = s.heightSplits as { cluster?: number; anchor?: number; gap?: number } | undefined;
-      if (splits) {
-        const values = [splits.cluster, splits.anchor, splits.gap].filter(v => v !== undefined) as number[];
-        if (values.some(v => v > 1.0)) {
-          autoFixInfo.push(`Section "${s.id}" heightSplits auto-corrected`);
-        }
-      }
     }
 
     // valid is based on real errors only — auto-fix info is appended after for logging

--- a/src/lib/pipeline/checkpoint-validators.ts
+++ b/src/lib/pipeline/checkpoint-validators.ts
@@ -401,7 +401,7 @@ export function validateGatekeeperManifest(manifestJson: string): ValidationResu
         if (splits.cluster !== undefined && splits.cluster > 1.0) splits.cluster = splits.cluster / 100;
         if (splits.anchor !== undefined && splits.anchor > 1.0) splits.anchor = splits.anchor / 100;
         if (splits.gap !== undefined && splits.gap > 1.0) splits.gap = splits.gap / 100;
-        errors.push(`Section "${s.id}" heightSplits auto-corrected from integers to decimals (${JSON.stringify(splits)})`);
+        // Tracked as auto-fix, not a real error (appended after valid check)
       }
     }
   }
@@ -437,25 +437,44 @@ export function validateGatekeeperManifest(manifestJson: string): ValidationResu
     }
   }
 
-  // 11. Visual enrichment — log warnings but DON'T deduct score.
-  // These fields (shape, sizeClass, labelDisplay) are auto-fixed to sensible defaults
-  // by the completeness validator. Penalizing what gets auto-corrected causes unnecessary
-  // gatekeeper failures on otherwise valid manifests.
+  // 11. Visual enrichment — log as info only (NOT errors).
+  // These fields are auto-fixed by the completeness validator. Including them in
+  // errors[] makes valid=false which blocks the pipeline even when score >= 9.0.
   const totalControls = controls.length;
   if (totalControls > 0) {
     const missingShape = controls.filter(c => !c.shape).length;
     const missingSizeClass = controls.filter(c => !c.sizeClass).length;
     const missingLabelDisplay = controls.filter(c => !c.labelDisplay).length;
 
+    // Log as info in errors array with "(auto-fixed)" suffix so they show in logs
+    // but DON'T affect the valid flag — use a separate warnings array
+    const autoFixInfo: string[] = [];
     if (missingShape > 0) {
-      errors.push(`${missingShape}/${totalControls} controls missing shape (auto-fixed)`);
+      autoFixInfo.push(`${missingShape}/${totalControls} controls missing shape (auto-fixed)`);
     }
     if (missingSizeClass > 0) {
-      errors.push(`${missingSizeClass}/${totalControls} controls missing sizeClass (auto-fixed)`);
+      autoFixInfo.push(`${missingSizeClass}/${totalControls} controls missing sizeClass (auto-fixed)`);
     }
     if (missingLabelDisplay > 0) {
-      errors.push(`${missingLabelDisplay}/${totalControls} controls missing labelDisplay (auto-fixed)`);
+      autoFixInfo.push(`${missingLabelDisplay}/${totalControls} controls missing labelDisplay (auto-fixed)`);
     }
+
+    // Check for heightSplits auto-corrections
+    for (const s of sections) {
+      const splits = s.heightSplits as { cluster?: number; anchor?: number; gap?: number } | undefined;
+      if (splits) {
+        const values = [splits.cluster, splits.anchor, splits.gap].filter(v => v !== undefined) as number[];
+        if (values.some(v => v > 1.0)) {
+          autoFixInfo.push(`Section "${s.id}" heightSplits auto-corrected`);
+        }
+      }
+    }
+
+    // valid is based on real errors only — auto-fix info is appended after for logging
+    const valid = errors.length === 0;
+    errors.push(...autoFixInfo);
+    score = Math.max(0, score);
+    return { valid, errors, score };
   }
 
   score = Math.max(0, score);

--- a/src/lib/pipeline/checkpoint-validators.ts
+++ b/src/lib/pipeline/checkpoint-validators.ts
@@ -942,22 +942,15 @@ export function validateManifestCompleteness(
   for (const c of controls) {
     if (duplicateIds.has(c.id)) continue; // Already penalized
 
-    // shape
+    // shape, sizeClass, labelDisplay — auto-fixed to defaults, don't penalize
     if (!c.shape) {
-      score -= 0.5;
-      missing.push({ controlId: c.id, field: 'shape', severity: 'major' });
+      missing.push({ controlId: c.id, field: 'shape', severity: 'minor' });
     }
-
-    // sizeClass
     if (!c.sizeClass) {
-      score -= 0.5;
-      missing.push({ controlId: c.id, field: 'sizeClass', severity: 'major' });
+      missing.push({ controlId: c.id, field: 'sizeClass', severity: 'minor' });
     }
-
-    // labelDisplay
     if (!c.labelDisplay) {
-      score -= 0.5;
-      missing.push({ controlId: c.id, field: 'labelDisplay', severity: 'major' });
+      missing.push({ controlId: c.id, field: 'labelDisplay', severity: 'minor' });
     }
 
     // buttonStyle on buttons

--- a/src/lib/pipeline/types.ts
+++ b/src/lib/pipeline/types.ts
@@ -86,7 +86,8 @@ export type EscalationType =
   | 'geometric-mismatch'
   | 'two-strike-halt'
   | 'physical-impossibility'
-  | 'template-review';
+  | 'template-review'
+  | 'editor-ready';
 
 export interface Escalation {
   id: string;


### PR DESCRIPTION
## Summary

### Editor Features
- **Hide section frame**: Toggle in Properties panel — section border/header hidden in preview/production, controls still render. For combining sections visually (e.g., Common + Scene as one panel area).
- **Pad label font size**: PadButton now respects labelFontSize slider (was hardcoded 11px). Works for single and multi-select.
- **Multi-select font size**: Font size slider now visible when multiple controls are selected. Select all 16 pads, adjust once.

### Pipeline Fixes
- **Gatekeeper scoring**: spatialNeighbors, densityTargets, panelBoundingBox are enrichment fields the layout engine computes — no longer deduct score. Prevents $42+ retry loops on valid manifests.
- **Auto-fix vs scoring**: valid flag computed from real errors only, auto-fix info messages appended after. Prevents false failures.
- **Completeness validator**: Added default auto-fix rules for shape (all types) and labelDisplay (all types) so scoring runs against post-fix state.
- **editor-ready escalation**: Pipeline pausing for editor now shows green "Send to Contractor" banner instead of red "agent failure".

## Test plan
- [ ] Select section → "Hide Frame" toggle → preview hides border
- [ ] Select pad → font size slider changes pad label size
- [ ] Multi-select 16 pads → font size slider visible, changes all
- [ ] Restart DeepMind 12 → gatekeeper passes (score 10.0)
- [ ] New pipeline reaching editor pause → shows green banner
- [ ] `npx vitest run` — 1028 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)