### PR TITLE
feat: events timeline, contractor history, no-lock submit, admin edit protection

### DIFF
--- a/scripts/pipeline-runner.ts
+++ b/scripts/pipeline-runner.ts
@@ -1269,6 +1269,107 @@ async function doPhase0LayoutEngine(state: PipelineState) {
         message: `Layout Engine: ${templateCount} templates generated for ${controlCount} controls`,
       });
       completePhase(state, 'phase-0-layout-engine', 10, true);
+
+      // Generate manifest-editor.json from gatekeeper manifest so the editor
+      // can load it immediately. Without this, "Send to Contractor" fails because
+      // manifest-editor.json doesn't exist until the admin makes a manual edit.
+      const editorManifestPath = path.join(pipelineDir, 'manifest-editor.json');
+      if (!fs.existsSync(editorManifestPath)) {
+        try {
+          const gkManifest = JSON.parse(fs.readFileSync(paths().manifest, 'utf-8'));
+          const dims = gkManifest.deviceDimensions ?? { widthMm: 800, depthMm: 400 };
+          const aspect = dims.widthMm / dims.depthMm;
+          const canvasWidth = Math.round(Math.max(1200, Math.min(2400, aspect * 800)));
+          const canvasHeight = Math.round(canvasWidth / aspect);
+
+          const sections: Record<string, any> = {};
+          const controls: Record<string, any> = {};
+          const editorLabels: any[] = [];
+
+          // Convert sections: percentage bounding boxes → pixel positions
+          for (const s of (gkManifest.sections ?? [])) {
+            const bbox = s.panelBoundingBox ?? { x: 0, y: 0, w: 100, h: 100 };
+            sections[s.id] = {
+              id: s.id,
+              headerLabel: s.headerLabel ?? s.id.toUpperCase(),
+              archetype: s.archetype ?? 'single-column',
+              x: Math.round((bbox.x / 100) * canvasWidth),
+              y: Math.round((bbox.y / 100) * canvasHeight),
+              w: Math.round((bbox.w / 100) * canvasWidth),
+              h: Math.round((bbox.h / 100) * canvasHeight),
+              childIds: s.controls ?? [],
+            };
+          }
+
+          // Convert controls: distribute within their section bounds
+          for (const c of (gkManifest.controls ?? [])) {
+            const sectionId = c.section ?? '';
+            const section = sections[sectionId];
+            const sectionControls = section?.childIds ?? [];
+            const idx = sectionControls.indexOf(c.id);
+            const count = sectionControls.length || 1;
+
+            // Grid layout within section
+            const cols = Math.ceil(Math.sqrt(count));
+            const row = Math.floor(idx / cols);
+            const col = idx % cols;
+            const cellW = (section?.w ?? 200) / cols;
+            const cellH = (section?.h ?? 200) / Math.ceil(count / cols);
+
+            controls[c.id] = {
+              id: c.id,
+              label: c.verbatimLabel ?? c.id,
+              type: c.type ?? 'button',
+              x: Math.round((section?.x ?? 0) + col * cellW + cellW * 0.1),
+              y: Math.round((section?.y ?? 0) + row * cellH + cellH * 0.1),
+              w: Math.round(cellW * 0.8),
+              h: Math.round(cellH * 0.8),
+              sectionId,
+              labelPosition: c.type === 'pad' ? 'on-button' : 'above',
+              locked: false,
+            };
+
+            // Create editorLabel
+            editorLabels.push({
+              text: c.verbatimLabel ?? c.id,
+              controlId: c.id,
+              x: Math.round((section?.x ?? 0) + col * cellW + cellW * 0.1),
+              y: Math.round((section?.y ?? 0) + row * cellH - 12),
+              w: Math.max((c.verbatimLabel ?? c.id).length * 7, 40),
+              h: 14,
+              fontSize: 9,
+            });
+          }
+
+          const editorManifest = {
+            _source: 'editor',
+            deviceId: gkManifest.deviceId ?? deviceId,
+            deviceName: gkManifest.deviceName ?? state.deviceName,
+            manufacturer: gkManifest.manufacturer ?? state.manufacturer,
+            sections,
+            controls,
+            editorLabels,
+            controlGroups: [],
+            canvasWidth,
+            canvasHeight,
+            controlScale: 1.0,
+            zoom: 1.0,
+            keyboard: gkManifest.keyboard ?? null,
+          };
+
+          fs.writeFileSync(editorManifestPath, JSON.stringify(editorManifest, null, 2));
+          appendLog(deviceId, {
+            level: 'info',
+            message: `Generated manifest-editor.json (${Object.keys(controls).length} controls, ${Object.keys(sections).length} sections, ${canvasWidth}x${canvasHeight} canvas)`,
+          });
+        } catch (genErr) {
+          appendLog(deviceId, {
+            level: 'warn',
+            message: `Could not generate manifest-editor.json: ${(genErr as Error).message}. Admin can create it by opening the editor.`,
+          });
+        }
+      }
+
       // Pause for editor — the contractor positions controls via the hosted editor.
       // Use "Send to Contractor" on the pipeline detail page to upload to Blob.
       createEscalation(state, 'editor-ready',

--- a/src/app/api/hosted/panels/[deviceId]/route.ts
+++ b/src/app/api/hosted/panels/[deviceId]/route.ts
@@ -50,10 +50,11 @@ export async function PUT(
     return NextResponse.json({ error: 'Device not found' }, { status: 404 });
   }
 
-  // Server-side lock: reject saves when panel is under review or approved
-  if (status.status === 'submitted' || status.status === 'approved') {
+  // Server-side lock: only reject saves when approved (final state).
+  // Contractor can keep editing and re-submitting while in 'submitted' status.
+  if (status.status === 'approved') {
     return NextResponse.json(
-      { error: 'Panel is locked for review', status: status.status },
+      { error: 'Panel is approved — no further edits', status: status.status },
       { status: 403 },
     );
   }

--- a/src/app/api/hosted/panels/[deviceId]/status/route.ts
+++ b/src/app/api/hosted/panels/[deviceId]/status/route.ts
@@ -50,7 +50,13 @@ export async function PATCH(
       : (adminNote?.trim() || undefined),
   };
 
-  const events = [...(existing.events ?? []), event];
+  // Deduplicate: if last event is same type, update it instead of appending.
+  // Prevents unbounded growth from rapid re-submits (submitted→submitted).
+  const prevEvents = existing.events ?? [];
+  const lastEvent = prevEvents[prevEvents.length - 1];
+  const events = (lastEvent && lastEvent.type === event.type && lastEvent.by === event.by)
+    ? [...prevEvents.slice(0, -1), event]  // Replace last
+    : [...prevEvents, event];              // Append new
 
   await putDeviceStatus(deviceId, {
     ...existing,

--- a/src/app/api/hosted/panels/[deviceId]/status/route.ts
+++ b/src/app/api/hosted/panels/[deviceId]/status/route.ts
@@ -1,11 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getDeviceStatus, putDeviceStatus, isValidTransition, type DeviceStatus } from '@/lib/hosted-storage';
+import { getDeviceStatus, putDeviceStatus, isValidTransition, backupManifest, type DeviceStatus, type StatusEvent } from '@/lib/hosted-storage';
 
 const VALID_STATUSES: DeviceStatus[] = ['ready', 'in-progress', 'submitted', 'approved'];
 
 /**
  * PATCH /api/hosted/panels/{deviceId}/status
  * Writes ONLY to status.json blob — completely independent of manifest.
+ * Appends a StatusEvent on every transition for timeline tracking.
  */
 export async function PATCH(
   request: NextRequest,
@@ -31,14 +32,33 @@ export async function PATCH(
     );
   }
 
+  // Backup manifest on contractor submit (creates restore point)
+  if (status === 'submitted') {
+    await backupManifest(deviceId);
+  }
+
+  // Build timeline event
+  const now = new Date().toISOString();
+  const event: StatusEvent = {
+    type: status === 'submitted' ? 'submitted'
+      : status === 'approved' ? 'approved'
+      : status === 'in-progress' && adminNote ? 'changes-requested'
+      : 'sent-to-contractor',
+    timestamp: now,
+    by: status === 'submitted' ? 'contractor' : 'admin',
+    note: status === 'submitted' ? (contractorNote?.trim() || undefined)
+      : (adminNote?.trim() || undefined),
+  };
+
+  const events = [...(existing.events ?? []), event];
+
   await putDeviceStatus(deviceId, {
     ...existing,
     status,
-    // Admin note: set on request-changes, preserved through submitted, cleared on approved
     adminNote: status === 'approved' ? undefined : (adminNote ?? existing.adminNote),
-    // Contractor note: set on submit, cleared when admin acts
     contractorNote: status === 'submitted' ? (contractorNote ?? existing.contractorNote) : undefined,
-    updatedAt: new Date().toISOString(),
+    events,
+    updatedAt: now,
   });
 
   return NextResponse.json({ ok: true, status });

--- a/src/app/api/pipeline/[deviceId]/send-to-hosted/route.ts
+++ b/src/app/api/pipeline/[deviceId]/send-to-hosted/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { initDevice, putPhoto, backupManifest } from '@/lib/hosted-storage';
+import { initDevice, putPhoto, backupManifest, getDeviceStatus, putDeviceStatus, type StatusEvent } from '@/lib/hosted-storage';
 import fs from 'fs';
 import path from 'path';
 
@@ -50,6 +50,16 @@ export async function POST(
     await backupManifest(deviceId);
 
     // Write both blobs (status.json + manifest.json)
+    // Preserve existing events and append sent-to-contractor event
+    const existingStatus = await getDeviceStatus(deviceId);
+    const sentEvent: StatusEvent = {
+      type: 'sent-to-contractor',
+      timestamp: new Date().toISOString(),
+      by: 'admin',
+      note: note?.trim() || undefined,
+    };
+    const events = [...(existingStatus?.events ?? []), sentEvent];
+
     await initDevice(
       deviceId,
       deviceName,
@@ -57,6 +67,14 @@ export async function POST(
       manifest,
       { adminNote: note },
     );
+
+    // initDevice creates fresh status — re-write with preserved events
+    if (existingStatus || events.length > 0) {
+      const freshStatus = await getDeviceStatus(deviceId);
+      if (freshStatus) {
+        await putDeviceStatus(deviceId, { ...freshStatus, events });
+      }
+    }
 
     // Upload photos
     let photoCount = 0;

--- a/src/app/api/pipeline/[deviceId]/send-to-hosted/route.ts
+++ b/src/app/api/pipeline/[deviceId]/send-to-hosted/route.ts
@@ -49,7 +49,6 @@ export async function POST(
     // Backup contractor's current manifest before overwriting
     await backupManifest(deviceId);
 
-    // Write both blobs (status.json + manifest.json)
     // Preserve existing events and append sent-to-contractor event
     const existingStatus = await getDeviceStatus(deviceId);
     const sentEvent: StatusEvent = {
@@ -60,20 +59,13 @@ export async function POST(
     };
     const events = [...(existingStatus?.events ?? []), sentEvent];
 
-    await initDevice(
-      deviceId,
-      deviceName,
-      manufacturer,
-      manifest,
-      { adminNote: note },
-    );
+    // Write both blobs (status.json + manifest.json)
+    await initDevice(deviceId, deviceName, manufacturer, manifest, { adminNote: note });
 
-    // initDevice creates fresh status — re-write with preserved events
-    if (existingStatus || events.length > 0) {
-      const freshStatus = await getDeviceStatus(deviceId);
-      if (freshStatus) {
-        await putDeviceStatus(deviceId, { ...freshStatus, events });
-      }
+    // Immediately re-apply preserved events (initDevice creates fresh status without them)
+    const freshStatus = await getDeviceStatus(deviceId);
+    if (freshStatus) {
+      await putDeviceStatus(deviceId, { ...freshStatus, events, isSandbox: existingStatus?.isSandbox });
     }
 
     // Upload photos

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -3,6 +3,13 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 
+interface StatusEvent {
+  type: string;
+  timestamp: string;
+  note?: string;
+  by: 'admin' | 'contractor';
+}
+
 interface DeviceSummary {
   deviceId: string;
   deviceName: string;
@@ -11,6 +18,7 @@ interface DeviceSummary {
   updatedAt: string;
   adminNote?: string;
   contractorNote?: string;
+  events?: StatusEvent[];
 }
 
 const STATUS_CONFIG: Record<string, { label: string; dot: string }> = {
@@ -117,6 +125,38 @@ export default function EditorListPage() {
                     <div className="mt-3 rounded border border-amber-600/30 bg-amber-900/15 px-3 py-2">
                       <p className="text-[10px] text-amber-400 font-medium mb-0.5">Feedback from reviewer:</p>
                       <p className="text-xs text-amber-300/80 whitespace-pre-wrap">{d.adminNote}</p>
+                    </div>
+                  )}
+
+                  {/* Timeline */}
+                  {(d.events ?? []).length > 0 && (
+                    <div className="mt-3 space-y-1">
+                      <p className="text-[10px] text-gray-500 font-medium">Activity</p>
+                      {[...(d.events ?? [])].reverse().slice(0, 5).map((ev, i) => (
+                        <div key={i} className="flex items-start gap-2 text-[10px]">
+                          <span className={`mt-0.5 w-1.5 h-1.5 rounded-full flex-shrink-0 ${
+                            ev.type === 'submitted' ? 'bg-blue-400'
+                            : ev.type === 'approved' ? 'bg-green-400'
+                            : ev.type === 'changes-requested' ? 'bg-amber-400'
+                            : 'bg-gray-400'
+                          }`} />
+                          <div className="flex-1 min-w-0">
+                            <span className="text-gray-400">
+                              {ev.by === 'contractor' ? 'You' : 'Reviewer'}
+                              {ev.type === 'submitted' ? ' submitted'
+                                : ev.type === 'approved' ? ' approved'
+                                : ev.type === 'changes-requested' ? ' requested changes'
+                                : ' sent to you'}
+                            </span>
+                            <span className="text-gray-600 ml-1">
+                              {new Date(ev.timestamp).toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
+                            </span>
+                            {ev.note && (
+                              <p className="text-gray-500 truncate mt-0.5">{ev.note}</p>
+                            )}
+                          </div>
+                        </div>
+                      ))}
                     </div>
                   )}
                 </div>

--- a/src/components/admin/ContractorSubmissions.tsx
+++ b/src/components/admin/ContractorSubmissions.tsx
@@ -3,6 +3,13 @@
 import { useEffect, useState, useCallback } from 'react';
 import { motion } from 'framer-motion';
 
+interface StatusEvent {
+  type: string;
+  timestamp: string;
+  note?: string;
+  by: 'admin' | 'contractor';
+}
+
 interface DeviceState {
   deviceId: string;
   deviceName: string;
@@ -11,6 +18,7 @@ interface DeviceState {
   updatedAt: string;
   adminNote?: string;
   contractorNote?: string;
+  events?: StatusEvent[];
 }
 
 interface DeviceIssue {
@@ -323,12 +331,22 @@ export default function ContractorSubmissions() {
                       {d.manufacturer} {d.deviceName}
                     </span>
                     <p className={`text-[10px] ${style.text}`}>{label}</p>
-                    {d.contractorNote && d.status === 'submitted' && (
-                      <p className="text-[11px] text-blue-400/70 mt-0.5">Contractor: {d.contractorNote}</p>
-                    )}
-                    {d.adminNote && d.status === 'in-progress' && (
-                      <p className="text-[11px] text-amber-400/70 mt-0.5">Your feedback: {d.adminNote}</p>
-                    )}
+                    {d.contractorNote && d.status === 'submitted' && (() => {
+                      const submitEvent = [...(d.events ?? [])].reverse().find(e => e.type === 'submitted');
+                      return (
+                        <p className="text-[11px] text-blue-400/70 mt-0.5">
+                          Contractor{submitEvent ? ` (${new Date(submitEvent.timestamp).toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })})` : ''}: {d.contractorNote}
+                        </p>
+                      );
+                    })()}
+                    {d.adminNote && d.status === 'in-progress' && (() => {
+                      const reviewEvent = [...(d.events ?? [])].reverse().find(e => e.type === 'changes-requested');
+                      return (
+                        <p className="text-[11px] text-amber-400/70 mt-0.5">
+                          Your feedback{reviewEvent ? ` (${new Date(reviewEvent.timestamp).toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })})` : ''}: {d.adminNote}
+                        </p>
+                      );
+                    })()}
                   </div>
                 </div>
 

--- a/src/components/admin/ContractorSubmissions.tsx
+++ b/src/components/admin/ContractorSubmissions.tsx
@@ -136,12 +136,17 @@ export default function ContractorSubmissions() {
   };
 
   const handleReview = async (deviceId: string) => {
+    if (!confirm('This will pull the contractor\'s latest version from Blob. Any local edits you made will be overwritten. Continue?')) return;
     setActing(deviceId);
     try {
       await fetch(`/api/pipeline/${deviceId}/pull-from-hosted`, { method: 'POST' });
     } catch { /* pull failed — open editor with local state */ }
     setActing(null);
-    // Force fresh load — bypass Zustand store cache from previous session
+    window.open(`/admin/${deviceId}/editor?reload=${Date.now()}`, '_blank');
+  };
+
+  const handleOpenEditor = (deviceId: string) => {
+    // Open editor WITHOUT pulling from Blob — preserves local admin edits
     window.open(`/admin/${deviceId}/editor?reload=${Date.now()}`, '_blank');
   };
 
@@ -334,7 +339,7 @@ export default function ContractorSubmissions() {
                     </span>
                   )}
 
-                  {/* Open/Review — always available */}
+                  {/* Pull & Review — pulls contractor's latest from Blob then opens editor */}
                   <button
                     onClick={() => handleReview(d.deviceId)}
                     disabled={acting === d.deviceId}
@@ -343,8 +348,18 @@ export default function ContractorSubmissions() {
                         ? 'border border-amber-600 bg-amber-700/30 text-amber-300 hover:bg-amber-700/50'
                         : 'border border-gray-600 bg-gray-800 text-gray-400 hover:bg-gray-700'
                     }`}
+                    title="Pull contractor's latest edits from Blob, then open editor"
                   >
-                    {acting === d.deviceId ? 'Loading...' : isSubmitted ? 'Review →' : 'Open →'}
+                    {acting === d.deviceId ? 'Pulling...' : isSubmitted ? 'Pull & Review' : 'Pull Latest'}
+                  </button>
+
+                  {/* Open Editor — opens with local state, no Blob pull */}
+                  <button
+                    onClick={() => handleOpenEditor(d.deviceId)}
+                    className="rounded px-3 py-1.5 text-[10px] font-medium border border-gray-600 bg-gray-800 text-gray-400 hover:bg-gray-700 transition-colors"
+                    title="Open editor with local state — won't overwrite your edits"
+                  >
+                    Edit →
                   </button>
 
                   {/* Approve + Request Changes — submitted only */}

--- a/src/components/panel-editor/EditorToolbar.tsx
+++ b/src/components/panel-editor/EditorToolbar.tsx
@@ -18,6 +18,16 @@ function SubmitForReviewButton({ deviceId, disabled }: { deviceId: string; disab
   const handleSubmit = async () => {
     setSubmitting(true);
     try {
+      // Flush current editor state to Blob BEFORE changing status.
+      // Prevents race where submit fires before the 2.5s auto-save debounce.
+      const state = useEditorStore.getState();
+      const { sections, controls, editorLabels, controlGroups, canvasWidth, canvasHeight, _manifestVersion, controlScale, zoom, cleanupGap, panelScale, keyboard } = state;
+      await fetch(`/api/hosted/panels/${deviceId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sections, controls, editorLabels, controlGroups, canvasWidth, canvasHeight, _manifestVersion, controlScale, zoom, cleanupGap, panelScale, keyboard }),
+      });
+
       const res = await fetch(`/api/hosted/panels/${deviceId}/status`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },

--- a/src/components/panel-editor/EditorToolbar.tsx
+++ b/src/components/panel-editor/EditorToolbar.tsx
@@ -13,12 +13,10 @@ function SubmitForReviewButton({ deviceId, disabled }: { deviceId: string; disab
   const [showModal, setShowModal] = useState(false);
   const [note, setNote] = useState('');
   const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
 
   const handleSubmit = async () => {
     setSubmitting(true);
-    // Lock editor IMMEDIATELY — blocks queued auto-save timers
-    useEditorStore.getState().setPreviewMode(true);
-    useEditorStore.getState().setSelectedIds([]);
     try {
       const res = await fetch(`/api/hosted/panels/${deviceId}/status`, {
         method: 'PATCH',
@@ -26,12 +24,11 @@ function SubmitForReviewButton({ deviceId, disabled }: { deviceId: string; disab
         body: JSON.stringify({ status: 'submitted', contractorNote: note.trim() || undefined }),
       });
       if (!res.ok) throw new Error('Submit failed');
-      if (typeof window !== 'undefined') {
-        (window as any).__submittedForReview = true;
-      }
+      setSubmitted(true);
       setShowModal(false);
+      // Auto-clear the submitted badge after 3 seconds so they can re-submit
+      setTimeout(() => setSubmitted(false), 3000);
     } catch {
-      useEditorStore.getState().setPreviewMode(false);
       alert('Failed to submit — please try again.');
     }
     setSubmitting(false);
@@ -41,11 +38,15 @@ function SubmitForReviewButton({ deviceId, disabled }: { deviceId: string; disab
     <>
       <button
         onClick={() => setShowModal(true)}
-        disabled={disabled}
-        className="flex h-7 items-center rounded px-3 text-[10px] font-medium whitespace-nowrap transition-colors border border-green-600 bg-green-700/30 text-green-300 hover:bg-green-700/50 disabled:opacity-30"
+        disabled={disabled || submitted}
+        className={`flex h-7 items-center rounded px-3 text-[10px] font-medium whitespace-nowrap transition-colors ${
+          submitted
+            ? 'border border-green-700 bg-green-700/20 text-green-400'
+            : 'border border-green-600 bg-green-700/30 text-green-300 hover:bg-green-700/50 disabled:opacity-30'
+        }`}
         title="Submit panel for owner review"
       >
-        Submit for Review
+        {submitted ? 'Submitted ✓' : 'Submit for Review'}
       </button>
 
       {showModal && (
@@ -426,13 +427,7 @@ export default function EditorToolbar({
           </span>
         ) : isHosted ? (
           <div data-tutorial="submit">
-            {(typeof window !== 'undefined' && (window as any).__submittedForReview) ? (
-              <span className="flex h-7 items-center px-3 text-[10px] font-medium text-green-400 border border-green-700 bg-green-700/20 rounded whitespace-nowrap">
-                Submitted ✓
-              </span>
-            ) : (
-              <SubmitForReviewButton deviceId={deviceId} disabled={previewMode} />
-            )}
+            <SubmitForReviewButton deviceId={deviceId} disabled={previewMode} />
           </div>
         ) : (
           <button

--- a/src/components/panel-editor/EditorToolbar.tsx
+++ b/src/components/panel-editor/EditorToolbar.tsx
@@ -1,12 +1,86 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useEditorStore } from './store';
 import type { SnapGrid } from './store';
 import VersionHistoryDropdown from './VersionHistoryDropdown';
 import { isHosted } from '@/lib/env';
 
 const SNAP_OPTIONS: SnapGrid[] = [1, 2, 4, 8, 16, 32];
+
+/** Blob version history for contractor (hosted mode) */
+function HostedHistoryButton({ deviceId }: { deviceId: string }) {
+  const [open, setOpen] = useState(false);
+  const [history, setHistory] = useState<Array<{ name: string; url: string; timestamp: string; sizeBytes: number }>>([]);
+  const [restoring, setRestoring] = useState(false);
+
+  const fetchHistory = useCallback(() => {
+    fetch(`/api/hosted/panels/${deviceId}/history`)
+      .then(r => r.ok ? r.json() : [])
+      .then(data => setHistory(Array.isArray(data) ? data : []))
+      .catch(() => {});
+  }, [deviceId]);
+
+  useEffect(() => {
+    if (open) fetchHistory();
+  }, [open, fetchHistory]);
+
+  const handleRestore = async (url: string) => {
+    if (!confirm('Restore this version? Your current work will be backed up first.')) return;
+    setRestoring(true);
+    try {
+      await fetch(`/api/hosted/panels/${deviceId}/history`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url }),
+      });
+      window.location.reload();
+    } catch {
+      alert('Restore failed');
+    }
+    setRestoring(false);
+  };
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setOpen(!open)}
+        className="flex h-7 items-center rounded px-2 text-[10px] text-gray-400 border border-gray-700 hover:bg-gray-800 transition-colors"
+        title="Version history"
+      >
+        ↺
+      </button>
+      {open && (
+        <>
+          <div className="fixed inset-0 z-[99]" onClick={() => setOpen(false)} />
+          <div className="absolute right-0 top-8 z-[100] w-64 rounded-lg border border-gray-700 bg-[#111122] p-3 shadow-2xl">
+            <h4 className="text-[11px] font-semibold text-gray-300 mb-2">Version History</h4>
+            {history.length === 0 ? (
+              <p className="text-[10px] text-gray-600">No backups yet</p>
+            ) : (
+              <div className="space-y-1.5 max-h-48 overflow-y-auto">
+                {history.map((h) => (
+                  <div key={h.name} className="flex items-center justify-between text-[10px]">
+                    <span className="text-gray-400">
+                      {new Date(h.timestamp).toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
+                    </span>
+                    <button
+                      onClick={() => handleRestore(h.url)}
+                      disabled={restoring}
+                      className="text-blue-400 hover:text-blue-300 disabled:opacity-50 transition-colors"
+                    >
+                      Restore
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
 
 /** Submit for Review button with note modal */
 function SubmitForReviewButton({ deviceId, disabled }: { deviceId: string; disabled: boolean }) {
@@ -436,8 +510,9 @@ export default function EditorToolbar({
             Practice Mode
           </span>
         ) : isHosted ? (
-          <div data-tutorial="submit">
+          <div data-tutorial="submit" className="flex items-center gap-1.5">
             <SubmitForReviewButton deviceId={deviceId} disabled={previewMode} />
+            <HostedHistoryButton deviceId={deviceId} />
           </div>
         ) : (
           <button

--- a/src/components/panel-editor/LayersPanel.tsx
+++ b/src/components/panel-editor/LayersPanel.tsx
@@ -271,14 +271,38 @@ function SectionItem({ sectionId }: { sectionId: string }) {
         <button
           onClick={handleSectionClick}
           className={`flex flex-1 items-center gap-1.5 py-1 pr-2 text-left text-[11px] font-medium ${
-            isSelected ? 'text-white' : 'text-gray-300'
+            section.hidden ? 'text-gray-600 italic' : isSelected ? 'text-white' : 'text-gray-300'
           }`}
         >
           <span className="flex-1 truncate">{truncate(displayName, 18)}</span>
+          {section.hidden && (
+            <span className="flex-shrink-0 text-[8px] text-amber-500/60">hidden</span>
+          )}
           <span className="flex-shrink-0 text-[9px] text-gray-500">{controlCount}</span>
           <span className="flex-shrink-0 rounded bg-gray-700/60 px-1 py-0.5 text-[8px] text-gray-400 uppercase leading-none">
             {truncate(section.archetype, 10)}
           </span>
+        </button>
+
+        {/* Visibility toggle */}
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            useEditorStore.getState().pushSnapshot();
+            useEditorStore.getState().updateSection(sectionId, { hidden: !section.hidden });
+          }}
+          className={`flex h-7 w-5 flex-shrink-0 items-center justify-center transition-colors ${
+            section.hidden ? 'text-amber-500/60 hover:text-amber-400' : 'text-gray-600 hover:text-gray-300'
+          }`}
+          title={section.hidden ? 'Show section' : 'Hide section'}
+        >
+          <svg className="h-3 w-3" viewBox="0 0 16 16" fill="currentColor">
+            {section.hidden ? (
+              <path d="M13.5 8s-2.2 3.5-5.5 3.5S2.5 8 2.5 8s2.2-3.5 5.5-3.5S13.5 8 13.5 8zM8 10a2 2 0 100-4 2 2 0 000 4z" opacity="0.4" />
+            ) : (
+              <path d="M13.5 8s-2.2 3.5-5.5 3.5S2.5 8 2.5 8s2.2-3.5 5.5-3.5S13.5 8 13.5 8zM8 10a2 2 0 100-4 2 2 0 000 4z" />
+            )}
+          </svg>
         </button>
       </div>
 

--- a/src/components/panel-editor/PanCanvas.tsx
+++ b/src/components/panel-editor/PanCanvas.tsx
@@ -130,7 +130,7 @@ export default function PanCanvas() {
           <DragSelectRect />
 
           {/* Section frames — visual boxes + banners only (no child controls) */}
-          {sectionEntries.map((section, index) => (
+          {sectionEntries.filter((s) => !s.hidden).map((section, index) => (
             <SectionFrame key={section.id} sectionId={section.id} zIndex={index + 1} />
           ))}
 

--- a/src/components/panel-editor/PanelEditor.tsx
+++ b/src/components/panel-editor/PanelEditor.tsx
@@ -174,24 +174,19 @@ function EditorShell({ deviceId, onRestoreVersion, adminNote, isSandbox }: { dev
       {previewMode && (
         <div className="flex h-10 items-center justify-between border-b border-amber-700/40 bg-amber-900/20 px-4">
           <span className="text-sm text-amber-300 truncate">
-            {isHosted && (typeof window !== 'undefined' && (window as any).__submittedForReview)
-              ? '✓ Submitted for review — let the owner know you\'re done'
-              : buildStatus === 'approved' && exportMessage
-                ? `✓ ${exportMessage}`
-                : buildStatus === 'approved'
-                  ? '✓ Panel exported'
-                  : 'Preview Mode — clean panel view (click Preview to exit)'}
+            {buildStatus === 'approved' && exportMessage
+              ? `✓ ${exportMessage}`
+              : buildStatus === 'approved'
+                ? '✓ Panel exported'
+                : 'Preview Mode — clean panel view (click Preview to exit)'}
           </span>
           <div className="flex items-center gap-2">
-            {/* Hide "Back to Editor" after submit in hosted mode — contractor is locked out */}
-            {!(isHosted && typeof window !== 'undefined' && (window as any).__submittedForReview) && (
-              <button
-                onClick={() => { setPreviewMode(false); setBuildStatus('idle'); setExportMessage(null); }}
-                className="rounded border border-gray-600 bg-gray-800 px-3 py-1 text-xs text-gray-300 transition-colors hover:bg-gray-700"
-              >
-                Back to Editor
+            <button
+              onClick={() => { setPreviewMode(false); setBuildStatus('idle'); setExportMessage(null); }}
+              className="rounded border border-gray-600 bg-gray-800 px-3 py-1 text-xs text-gray-300 transition-colors hover:bg-gray-700"
+            >
+              Back to Editor
               </button>
-            )}
           </div>
         </div>
       )}
@@ -342,21 +337,10 @@ export default function PanelEditor({ deviceId, isSandbox }: PanelEditorProps) {
           // Initialize labels from controls if not yet done (migration)
           useEditorStore.getState().initLabelsFromControls();
 
-          // In hosted mode, capture admin note and lock/unlock based on status
+          // In hosted mode, capture admin note. Editor stays unlocked —
+          // contractor can keep editing and re-submit at any time.
           if (isHosted) {
             setAdminNote(data._adminNote ?? null);
-            if (data._status === 'submitted' || data._status === 'approved') {
-              useEditorStore.getState().setPreviewMode(true);
-              if (typeof window !== 'undefined') {
-                (window as any).__submittedForReview = true;
-              }
-            } else {
-              // Unlock — admin may have sent changes back
-              useEditorStore.getState().setPreviewMode(false);
-              if (typeof window !== 'undefined') {
-                (window as any).__submittedForReview = false;
-              }
-            }
           }
 
           setLoading(false);

--- a/src/lib/hosted-storage.ts
+++ b/src/lib/hosted-storage.ts
@@ -49,7 +49,7 @@ export interface DeviceSummary {
 const VALID_TRANSITIONS: Record<DeviceStatus, DeviceStatus[]> = {
   'ready': ['in-progress', 'submitted'],
   'in-progress': ['submitted'],
-  'submitted': ['approved', 'in-progress'],
+  'submitted': ['approved', 'in-progress', 'submitted'],
   'approved': ['in-progress'],
 };
 

--- a/src/lib/hosted-storage.ts
+++ b/src/lib/hosted-storage.ts
@@ -22,6 +22,15 @@ const PREFIX = 'devices';
 
 export type DeviceStatus = 'ready' | 'in-progress' | 'submitted' | 'approved';
 
+export type StatusEventType = 'sent-to-contractor' | 'submitted' | 'changes-requested' | 'approved';
+
+export interface StatusEvent {
+  type: StatusEventType;
+  timestamp: string;
+  note?: string;
+  by: 'admin' | 'contractor';
+}
+
 export interface DeviceStatusData {
   deviceId: string;
   deviceName: string;
@@ -30,6 +39,7 @@ export interface DeviceStatusData {
   adminNote?: string;       // admin → contractor (feedback, instructions)
   contractorNote?: string;  // contractor → admin (submission notes)
   isSandbox?: boolean;      // practice instrument — no submit, hidden from admin
+  events?: StatusEvent[];   // timeline of all submissions, reviews, approvals
   updatedAt: string;
 }
 
@@ -42,6 +52,7 @@ export interface DeviceSummary {
   adminNote?: string;
   contractorNote?: string;
   isSandbox?: boolean;
+  events?: StatusEvent[];
 }
 
 // ─── Valid state transitions ────────────────────────────────────────────────
@@ -198,6 +209,7 @@ export async function listDevices(opts?: { sandbox?: boolean }): Promise<DeviceS
             adminNote: data.adminNote,
             contractorNote: data.contractorNote,
             isSandbox: data.isSandbox,
+            events: data.events,
           } as DeviceSummary;
         } catch {
           return null;


### PR DESCRIPTION
## Summary

### Events Timeline
- Every status transition (submit, review, approve, send) appends a StatusEvent with timestamp, note, and who
- Contractor `/editor` page shows activity timeline (last 5 events with colored dots)
- Admin ContractorSubmissions shows timestamps on contractor notes and feedback

### Contractor Version History
- ↺ button in hosted editor toolbar — shows Blob backup history with Restore
- Backup created on every contractor submit (each submission is a restore point)

### No-Lock Submit
- Contractor can keep editing after submit — no more preview mode lock
- Submit flushes auto-save to Blob BEFORE status PATCH (prevents 2.5s race)
- submitted→submitted transition now valid (re-submit)

### Admin Edit Protection
- Split "Review →" into "Pull & Review" (pulls from Blob, warns about overwrite) and "Edit →" (opens local, preserves edits)
- Confirm dialog before Pull & Review to prevent accidental overwrites

### Editor Features
- Hide section frame — toggle in Layers panel + Properties panel
- Hidden sections disappear from editor canvas + preview
- Pad label font size now responds to slider (was hardcoded 11px)
- Multi-select font size slider for bulk label sizing

### Pipeline
- Auto-create manifest-editor.json after layout engine
- Gatekeeper scoring: enrichment fields don't fail validation
- editor-ready escalation type (green banner, not red error)

## Test plan
- [ ] Contractor submits → event in timeline, backup created
- [ ] Admin sends changes → event in timeline with timestamp
- [ ] Contractor sees activity timeline on /editor page
- [ ] ↺ history button shows backups, restore works
- [ ] Contractor can edit after submit, re-submit works
- [ ] Admin "Pull & Review" warns before overwrite
- [ ] Admin "Edit →" opens without pulling from Blob
- [ ] Hide section in layers panel → disappears from canvas
- [ ] Pad font size slider works (single + multi-select)
- [ ] `npx vitest run` — 1028 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)