### PR TITLE
fix: contractor Continue button after submit + local backup on pull

### DIFF
--- a/src/app/api/pipeline/[deviceId]/pull-from-hosted/route.ts
+++ b/src/app/api/pipeline/[deviceId]/pull-from-hosted/route.ts
@@ -33,6 +33,11 @@ export async function POST(
       fs.mkdirSync(pipelineDir, { recursive: true });
     }
     const editorPath = path.join(pipelineDir, 'manifest-editor.json');
+    // Backup local manifest before overwriting with Blob version
+    if (fs.existsSync(editorPath)) {
+      const backupPath = path.join(pipelineDir, `manifest-editor-backup-${new Date().toISOString().replace(/[:.]/g, '-')}.json`);
+      fs.copyFileSync(editorPath, backupPath);
+    }
     fs.writeFileSync(editorPath, JSON.stringify(manifest, null, 2));
 
     // Run export-manifest to write production JSON

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -104,16 +104,18 @@ export default function EditorListPage() {
                       </div>
                     </div>
 
-                    {(d.status === 'ready' || d.status === 'in-progress') && (
-                      <Link
-                        href={`/editor/${d.deviceId}`}
-                        className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-500 transition-colors"
-                      >
-                        {d.status === 'ready' ? 'Edit →' : 'Continue →'}
-                      </Link>
-                    )}
-                    {d.status === 'submitted' && (
-                      <span className="text-[11px] text-amber-400">Waiting for review</span>
+                    {(d.status === 'ready' || d.status === 'in-progress' || d.status === 'submitted') && (
+                      <div className="flex items-center gap-2">
+                        {d.status === 'submitted' && (
+                          <span className="text-[11px] text-amber-400">Submitted</span>
+                        )}
+                        <Link
+                          href={`/editor/${d.deviceId}`}
+                          className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-500 transition-colors"
+                        >
+                          {d.status === 'ready' ? 'Edit →' : 'Continue →'}
+                        </Link>
+                      </div>
                     )}
                     {d.status === 'approved' && (
                       <span className="text-[11px] text-green-400">✓ Complete</span>


### PR DESCRIPTION
## Summary
- Contractor list page shows "Continue →" button when status is 'submitted' — previously locked out with just "Waiting for review" text
- Local manifest-editor.json backed up with timestamp before pull-from-hosted overwrites it

## Test plan
- [ ] Contractor submits → sees "Submitted" + "Continue →" on list page
- [ ] Contractor clicks Continue → editor opens, can keep editing
- [ ] Admin clicks "Pull & Review" → local backup created before overwrite

🤖 Generated with [Claude Code](https://claude.com/claude-code)