### PR TITLE
feat: section frame modes — Full / Title Only / Hidden

### DIFF
--- a/src/components/controls/PanelRenderer.tsx
+++ b/src/components/controls/PanelRenderer.tsx
@@ -61,6 +61,7 @@ interface ManifestSection {
   id: string;
   headerLabel?: string;
   hidden?: boolean;
+  frameMode?: 'full' | 'header-only' | 'hidden';
   x: number;
   y: number;
   w: number;
@@ -377,11 +378,46 @@ export default function PanelRenderer({
       keyboard={manifest.keyboard}
     >
       {/* Section backgrounds */}
-      {(manifest.editorSections ?? []).filter((s) => !s.hidden).map((s) => (
-        <SectionContainer key={s.id} id={s.id}
-          x={s.x} y={s.y} w={s.w} h={s.h}
-          headerLabel={s.headerLabel} />
-      ))}
+      {(manifest.editorSections ?? []).map((s) => {
+        const mode = s.frameMode ?? (s.hidden ? 'hidden' : 'full');
+        if (mode === 'hidden') return null;
+        if (mode === 'header-only') {
+          // Floating title only — no container background
+          return s.headerLabel ? (
+            <div
+              key={s.id}
+              style={{
+                position: 'absolute',
+                left: s.x * scale,
+                top: s.y * scale,
+                width: s.w * scale,
+                height: 20 * scale,
+                display: 'flex',
+                alignItems: 'center',
+                paddingLeft: 8 * scale,
+                pointerEvents: 'none',
+                zIndex: 0,
+              }}
+            >
+              <span style={{
+                fontSize: 8 * scale,
+                fontWeight: 500,
+                textTransform: 'uppercase',
+                letterSpacing: '0.15em',
+                color: '#666',
+              }}>
+                {s.headerLabel}
+              </span>
+            </div>
+          ) : null;
+        }
+        // Full mode — render SectionContainer
+        return (
+          <SectionContainer key={s.id} id={s.id}
+            x={s.x} y={s.y} w={s.w} h={s.h}
+            headerLabel={s.headerLabel} />
+        );
+      })}
 
       {/* Controls */}
       {topLevelControls.map((ctrl) => {

--- a/src/components/controls/PanelRenderer.tsx
+++ b/src/components/controls/PanelRenderer.tsx
@@ -383,24 +383,25 @@ export default function PanelRenderer({
         if (mode === 'hidden') return null;
         if (mode === 'header-only') {
           // Floating title only — no container background
+          // Section coords are in pixels (same as SectionContainer), no scale needed
           return s.headerLabel ? (
             <div
               key={s.id}
               style={{
                 position: 'absolute',
-                left: s.x * scale,
-                top: s.y * scale,
-                width: s.w * scale,
-                height: 20 * scale,
+                left: s.x,
+                top: s.y,
+                width: s.w,
+                height: 20,
                 display: 'flex',
                 alignItems: 'center',
-                paddingLeft: 8 * scale,
+                paddingLeft: 8,
                 pointerEvents: 'none',
                 zIndex: 0,
               }}
             >
               <span style={{
-                fontSize: 8 * scale,
+                fontSize: 8,
                 fontWeight: 500,
                 textTransform: 'uppercase',
                 letterSpacing: '0.15em',

--- a/src/components/panel-editor/LayersPanel.tsx
+++ b/src/components/panel-editor/LayersPanel.tsx
@@ -268,37 +268,55 @@ function SectionItem({ sectionId }: { sectionId: string }) {
         </button>
 
         {/* Section name + metadata */}
-        <button
-          onClick={handleSectionClick}
-          className={`flex flex-1 items-center gap-1.5 py-1 pr-2 text-left text-[11px] font-medium ${
-            section.hidden ? 'text-gray-600 italic' : isSelected ? 'text-white' : 'text-gray-300'
-          }`}
-        >
-          <span className="flex-1 truncate">{truncate(displayName, 18)}</span>
-          {section.hidden && (
-            <span className="flex-shrink-0 text-[8px] text-amber-500/60">hidden</span>
-          )}
-          <span className="flex-shrink-0 text-[9px] text-gray-500">{controlCount}</span>
-          <span className="flex-shrink-0 rounded bg-gray-700/60 px-1 py-0.5 text-[8px] text-gray-400 uppercase leading-none">
-            {truncate(section.archetype, 10)}
-          </span>
-        </button>
+        {(() => {
+          const mode = section.frameMode ?? (section.hidden ? 'hidden' : 'full');
+          return (
+            <button
+              onClick={handleSectionClick}
+              className={`flex flex-1 items-center gap-1.5 py-1 pr-2 text-left text-[11px] font-medium ${
+                mode === 'hidden' ? 'text-gray-600 italic'
+                : mode === 'header-only' ? 'text-blue-300/70'
+                : isSelected ? 'text-white' : 'text-gray-300'
+              }`}
+            >
+              <span className="flex-1 truncate">{truncate(displayName, 18)}</span>
+              {mode === 'hidden' && (
+                <span className="flex-shrink-0 text-[8px] text-amber-500/60">hidden</span>
+              )}
+              {mode === 'header-only' && (
+                <span className="flex-shrink-0 text-[8px] text-blue-400/60">title</span>
+              )}
+              <span className="flex-shrink-0 text-[9px] text-gray-500">{controlCount}</span>
+              <span className="flex-shrink-0 rounded bg-gray-700/60 px-1 py-0.5 text-[8px] text-gray-400 uppercase leading-none">
+                {truncate(section.archetype, 10)}
+              </span>
+            </button>
+          );
+        })()}
 
-        {/* Visibility toggle */}
+        {/* Frame mode cycle toggle: full → header-only → hidden → full */}
         <button
           onClick={(e) => {
             e.stopPropagation();
             useEditorStore.getState().pushSnapshot();
-            useEditorStore.getState().updateSection(sectionId, { hidden: !section.hidden });
+            const mode = section.frameMode ?? (section.hidden ? 'hidden' : 'full');
+            const next = mode === 'full' ? 'header-only' : mode === 'header-only' ? 'hidden' : 'full';
+            useEditorStore.getState().updateSection(sectionId, { frameMode: next });
           }}
           className={`flex h-7 w-5 flex-shrink-0 items-center justify-center transition-colors ${
-            section.hidden ? 'text-amber-500/60 hover:text-amber-400' : 'text-gray-600 hover:text-gray-300'
+            (section.frameMode ?? (section.hidden ? 'hidden' : 'full')) === 'hidden'
+              ? 'text-amber-500/60 hover:text-amber-400'
+              : (section.frameMode === 'header-only')
+                ? 'text-blue-400/60 hover:text-blue-300'
+                : 'text-gray-600 hover:text-gray-300'
           }`}
-          title={section.hidden ? 'Show section' : 'Hide section'}
+          title={`Frame mode: ${section.frameMode ?? (section.hidden ? 'hidden' : 'full')} (click to cycle)`}
         >
           <svg className="h-3 w-3" viewBox="0 0 16 16" fill="currentColor">
-            {section.hidden ? (
-              <path d="M13.5 8s-2.2 3.5-5.5 3.5S2.5 8 2.5 8s2.2-3.5 5.5-3.5S13.5 8 13.5 8zM8 10a2 2 0 100-4 2 2 0 000 4z" opacity="0.4" />
+            {(section.frameMode ?? (section.hidden ? 'hidden' : 'full')) === 'hidden' ? (
+              <path d="M13.5 8s-2.2 3.5-5.5 3.5S2.5 8 2.5 8s2.2-3.5 5.5-3.5S13.5 8 13.5 8zM8 10a2 2 0 100-4 2 2 0 000 4z" opacity="0.3" />
+            ) : (section.frameMode === 'header-only') ? (
+              <path d="M13.5 8s-2.2 3.5-5.5 3.5S2.5 8 2.5 8s2.2-3.5 5.5-3.5S13.5 8 13.5 8zM8 10a2 2 0 100-4 2 2 0 000 4z" opacity="0.6" />
             ) : (
               <path d="M13.5 8s-2.2 3.5-5.5 3.5S2.5 8 2.5 8s2.2-3.5 5.5-3.5S13.5 8 13.5 8zM8 10a2 2 0 100-4 2 2 0 000 4z" />
             )}

--- a/src/components/panel-editor/PanCanvas.tsx
+++ b/src/components/panel-editor/PanCanvas.tsx
@@ -32,6 +32,7 @@ function storeToManifest(state: ReturnType<typeof useEditorStore.getState>): Pan
       id: s.id,
       headerLabel: s.headerLabel ?? undefined,
       hidden: s.hidden,
+      frameMode: s.frameMode,
       x: s.x,
       y: s.y,
       w: s.w,
@@ -130,7 +131,10 @@ export default function PanCanvas() {
           <DragSelectRect />
 
           {/* Section frames — visual boxes + banners only (no child controls) */}
-          {sectionEntries.filter((s) => !s.hidden).map((section, index) => (
+          {sectionEntries.filter((s) => {
+            const mode = s.frameMode ?? (s.hidden ? 'hidden' : 'full');
+            return mode !== 'hidden';
+          }).map((section, index) => (
             <SectionFrame key={section.id} sectionId={section.id} zIndex={index + 1} />
           ))}
 

--- a/src/components/panel-editor/PropertiesPanel/index.tsx
+++ b/src/components/panel-editor/PropertiesPanel/index.tsx
@@ -178,24 +178,35 @@ function SectionProperties({ section }: { section: SectionDef }) {
         )}
       </div>
 
-      {/* Hide section frame in preview/production */}
-      <div className="flex items-center justify-between">
+      {/* Section frame mode */}
+      <div className="space-y-1">
         <label className="text-[10px] uppercase tracking-wide text-gray-500">
-          Hide Frame
+          Frame Mode
         </label>
-        <button
-          onClick={() => {
-            pushSnapshot();
-            useEditorStore.getState().updateSection(section.id, { hidden: !section.hidden });
-          }}
-          className={`text-[9px] px-1.5 py-0.5 rounded transition-colors ${
-            section.hidden
-              ? 'bg-amber-600/30 text-amber-300 border border-amber-600'
-              : 'bg-gray-800 text-gray-500 border border-gray-700 hover:text-gray-300'
-          }`}
-        >
-          {section.hidden ? 'Hidden' : 'Visible'}
-        </button>
+        <div className="flex gap-1">
+          {([['full', 'Full'], ['header-only', 'Title Only'], ['hidden', 'Hidden']] as const).map(([mode, label]) => {
+            const currentMode = section.frameMode ?? (section.hidden ? 'hidden' : 'full');
+            const isActive = currentMode === mode;
+            return (
+              <button
+                key={mode}
+                onClick={() => {
+                  pushSnapshot();
+                  useEditorStore.getState().updateSection(section.id, { frameMode: mode });
+                }}
+                className={`flex-1 rounded px-1.5 py-1 text-[9px] font-medium transition-colors ${
+                  isActive
+                    ? mode === 'hidden' ? 'bg-amber-600/30 text-amber-300 border border-amber-600'
+                      : mode === 'header-only' ? 'bg-blue-600/30 text-blue-300 border border-blue-600'
+                      : 'bg-gray-600/30 text-gray-200 border border-gray-500'
+                    : 'bg-gray-800 text-gray-500 border border-gray-700 hover:text-gray-300'
+                }`}
+              >
+                {label}
+              </button>
+            );
+          })}
+        </div>
       </div>
 
       {/* Divider */}

--- a/src/components/panel-editor/SectionFrame.tsx
+++ b/src/components/panel-editor/SectionFrame.tsx
@@ -3,6 +3,7 @@
 import { useCallback } from 'react';
 import { Rnd } from 'react-rnd';
 import { useEditorStore } from './store';
+import { getFrameMode } from './store/manifestSlice';
 
 interface SectionFrameProps {
   sectionId: string;
@@ -72,6 +73,43 @@ export default function SectionFrame({ sectionId, zIndex = 1 }: SectionFrameProp
 
   if (!section) return null;
 
+  const mode = getFrameMode(section);
+
+  // Header-only mode: just a floating header bar, no body/border
+  if (mode === 'header-only') {
+    return (
+      <Rnd
+        position={{ x: section.x, y: section.y }}
+        size={{ width: section.w, height: 28 }}
+        scale={zoom}
+        dragGrid={[snapGrid, snapGrid]}
+        dragHandleClassName="section-drag-handle"
+        onDragStop={handleDragStop}
+        enableResizing={false}
+        style={{
+          zIndex: isSelected ? 100 : focusedSectionId === sectionId ? 99 : zIndex,
+        }}
+        onClick={handleClick}
+      >
+        <div
+          className="section-drag-handle flex items-center gap-2 px-2 h-7 cursor-grab active:cursor-grabbing select-none rounded"
+          style={{
+            backgroundColor: isSelected ? 'rgba(59,130,246,0.15)' : 'rgba(255,255,255,0.05)',
+            border: isSelected ? '1px solid rgba(59,130,246,0.5)' : '1px dashed rgba(255,255,255,0.15)',
+            transition: 'border-color 0.15s, background-color 0.15s',
+          }}
+        >
+          <span className="text-[10px] text-gray-400">⋮⋮</span>
+          <span className="text-[11px] font-semibold text-gray-400 uppercase tracking-wider truncate">
+            {section.headerLabel ?? sectionId}
+          </span>
+          <span className="text-[10px] text-gray-600 ml-auto">{(section.childIds ?? []).length}</span>
+        </div>
+      </Rnd>
+    );
+  }
+
+  // Full mode: border + header + resize
   return (
     <Rnd
       position={{ x: section.x, y: section.y }}

--- a/src/components/panel-editor/store/manifestSlice.ts
+++ b/src/components/panel-editor/store/manifestSlice.ts
@@ -144,7 +144,17 @@ export interface SectionDef {
   gridRows?: number;
   widthPercent?: number;
   complexity?: string;
-  hidden?: boolean; // Hide section frame in preview/production — controls still render
+  hidden?: boolean; // Legacy — use frameMode instead
+  frameMode?: 'full' | 'header-only' | 'hidden';
+}
+
+export type SectionFrameMode = 'full' | 'header-only' | 'hidden';
+
+/** Backwards-compatible frame mode reader */
+export function getFrameMode(section: SectionDef): SectionFrameMode {
+  if (section.frameMode) return section.frameMode;
+  if (section.hidden) return 'hidden';
+  return 'full';
 }
 
 // ─── Slice interface ────────────────────────────────────────────────────────
@@ -911,6 +921,10 @@ export const createManifestSlice: StateCreator<
   updateSection: (id, updates) => {
     const section = get().sections[id];
     if (!section) return;
+    // Sync hidden boolean with frameMode for backwards compatibility
+    if (updates.frameMode) {
+      updates.hidden = updates.frameMode === 'hidden' ? true : undefined;
+    }
     set((s) => ({
       sections: {
         ...s.sections,


### PR DESCRIPTION
## Summary

Sections now have 3 frame modes instead of a boolean hidden toggle:

- **Full** — border + header + resize (default, unchanged)
- **Title Only** — floating section title, no border/background. Controls appear as one continuous panel with labeled regions.
- **Hidden** — no border, no header. Section only visible in Layers panel.

### UI Controls
- **Properties panel**: 3-option pill selector (Full / Title Only / Hidden) replaces old Hide Frame toggle
- **Layers panel**: Eye icon cycles through modes on click. Badge shows "title" or "hidden". Section name color changes per mode.

### Rendering
- **Editor**: Title Only shows as a thin dashed header bar, draggable but not resizable
- **Preview/Production**: Title Only renders floating text label (8px, uppercase, same style as full section header)

### Data Model
- `frameMode?: 'full' | 'header-only' | 'hidden'` on SectionDef
- `getFrameMode()` helper for backwards compat (old `hidden: true` → 'hidden')
- `updateSection` syncs hidden boolean when frameMode changes

## Test plan
- [ ] Select section → Properties panel shows Full / Title Only / Hidden pills
- [ ] Set "Title Only" → border disappears, floating title stays on canvas
- [ ] Preview shows floating title text (no container background)
- [ ] Set "Hidden" → section disappears from canvas, visible in Layers
- [ ] Layers panel: click eye icon cycles through modes
- [ ] Old manifests with `hidden: true` still work (backwards compat)
- [ ] `npx vitest run` — 1028 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)