### PR TITLE
fix: canvas resize scaling + label tracking + preview font size

### DIFF
--- a/src/components/panel-editor/EditorToolbar.tsx
+++ b/src/components/panel-editor/EditorToolbar.tsx
@@ -478,7 +478,7 @@ export default function EditorToolbar({
               const val = parseInt(e.target.value, 10);
               if (!isNaN(val) && val !== canvasWidth && val >= 400) {
                 pushSnapshot();
-                setCanvasSize(val, canvasHeight);
+                scaleCanvas(val / canvasWidth);
               }
             }}
             onKeyDown={(e) => { if (e.key === 'Enter') (e.target as HTMLInputElement).blur(); }}
@@ -495,7 +495,7 @@ export default function EditorToolbar({
               const val = parseInt(e.target.value, 10);
               if (!isNaN(val) && val !== canvasHeight && val >= 300) {
                 pushSnapshot();
-                setCanvasSize(canvasWidth, val);
+                scaleCanvas(val / canvasHeight);
               }
             }}
             onKeyDown={(e) => { if (e.key === 'Enter') (e.target as HTMLInputElement).blur(); }}

--- a/src/components/panel-editor/PanCanvas.tsx
+++ b/src/components/panel-editor/PanCanvas.tsx
@@ -58,6 +58,7 @@ function storeToManifest(state: ReturnType<typeof useEditorStore.getState>): Pan
       positions: c.positions,
       positionLabels: c.positionLabels,
       rotation: c.rotation,
+      labelFontSize: c.labelFontSize,
       editorPosition: { x: c.x, y: c.y, w: c.w, h: c.h },
     })),
     editorLabels: (state.editorLabels ?? []).map((l: any) => ({

--- a/src/components/panel-editor/store/manifestSlice.ts
+++ b/src/components/panel-editor/store/manifestSlice.ts
@@ -1195,31 +1195,14 @@ export const createManifestSlice: StateCreator<
         };
       }
 
-      // Scale all label positions, widths, and font sizes.
-      // For linked labels, compute position from the already-rounded control
-      // to prevent rounding drift between label and its control.
-      const updatedLabels = (s.editorLabels as EditorLabel[]).map(l => {
-        const scaled = {
-          ...l,
-          x: Math.round(l.x * factor),
-          y: Math.round(l.y * factor),
-          w: l.w != null ? Math.round(l.w * factor) : l.w,
-          fontSize: Math.max(Math.round(l.fontSize * factor), 4),
-        };
-
-        if (l.controlId) {
-          const oldCtrl = s.controls[l.controlId];
-          const newCtrl = updatedControls[l.controlId];
-          if (oldCtrl && newCtrl) {
-            const offsetX = l.x - oldCtrl.x;
-            const offsetY = l.y - oldCtrl.y;
-            scaled.x = Math.round(newCtrl.x + offsetX * factor);
-            scaled.y = Math.round(newCtrl.y + offsetY * factor);
-          }
-        }
-
-        return scaled;
-      });
+      // Scale all label positions, widths, and font sizes
+      const updatedLabels = (s.editorLabels as EditorLabel[]).map(l => ({
+        ...l,
+        x: Math.round(l.x * factor),
+        y: Math.round(l.y * factor),
+        w: l.w != null ? Math.round(l.w * factor) : l.w,
+        fontSize: Math.max(Math.round(l.fontSize * factor), 4),
+      }));
 
       return {
         controls: updatedControls,

--- a/src/components/panel-editor/store/manifestSlice.ts
+++ b/src/components/panel-editor/store/manifestSlice.ts
@@ -1179,6 +1179,7 @@ export const createManifestSlice: StateCreator<
           y: Math.round(ctrl.y * factor),
           w: Math.round(ctrl.w * factor),
           h: Math.round(ctrl.h * factor),
+          labelFontSize: ctrl.labelFontSize ? Math.max(Math.round(ctrl.labelFontSize * factor), 4) : ctrl.labelFontSize,
         };
       }
 

--- a/src/components/panel-editor/store/manifestSlice.ts
+++ b/src/components/panel-editor/store/manifestSlice.ts
@@ -1195,14 +1195,31 @@ export const createManifestSlice: StateCreator<
         };
       }
 
-      // Scale all label positions, widths, and font sizes
-      const updatedLabels = (s.editorLabels as EditorLabel[]).map(l => ({
-        ...l,
-        x: Math.round(l.x * factor),
-        y: Math.round(l.y * factor),
-        w: l.w != null ? Math.round(l.w * factor) : l.w,
-        fontSize: Math.max(Math.round(l.fontSize * factor), 4),
-      }));
+      // Scale all label positions, widths, and font sizes.
+      // For linked labels, compute position from the already-rounded control
+      // to prevent rounding drift between label and its control.
+      const updatedLabels = (s.editorLabels as EditorLabel[]).map(l => {
+        const scaled = {
+          ...l,
+          x: Math.round(l.x * factor),
+          y: Math.round(l.y * factor),
+          w: l.w != null ? Math.round(l.w * factor) : l.w,
+          fontSize: Math.max(Math.round(l.fontSize * factor), 4),
+        };
+
+        if (l.controlId) {
+          const oldCtrl = s.controls[l.controlId];
+          const newCtrl = updatedControls[l.controlId];
+          if (oldCtrl && newCtrl) {
+            const offsetX = l.x - oldCtrl.x;
+            const offsetY = l.y - oldCtrl.y;
+            scaled.x = Math.round(newCtrl.x + offsetX * factor);
+            scaled.y = Math.round(newCtrl.y + offsetY * factor);
+          }
+        }
+
+        return scaled;
+      });
 
       return {
         controls: updatedControls,

--- a/src/components/panel-editor/store/manifestSlice.ts
+++ b/src/components/panel-editor/store/manifestSlice.ts
@@ -1195,14 +1195,28 @@ export const createManifestSlice: StateCreator<
         };
       }
 
-      // Scale all label positions, widths, and font sizes
-      const updatedLabels = (s.editorLabels as EditorLabel[]).map(l => ({
-        ...l,
-        x: Math.round(l.x * factor),
-        y: Math.round(l.y * factor),
-        w: l.w != null ? Math.round(l.w * factor) : l.w,
-        fontSize: Math.max(Math.round(l.fontSize * factor), 4),
-      }));
+      // Scale all label positions, widths, and font sizes.
+      // Linked labels compute position from their already-rounded control
+      // to prevent drift between label and control after repeated resizes.
+      const updatedLabels = (s.editorLabels as EditorLabel[]).map(l => {
+        const base = {
+          ...l,
+          x: Math.round(l.x * factor),
+          y: Math.round(l.y * factor),
+          w: l.w != null ? Math.round(l.w * factor) : l.w,
+          fontSize: Math.max(Math.round(l.fontSize * factor), 4),
+        };
+
+        // For linked labels, recompute from the rounded control position
+        const oldCtrl = l.controlId ? s.controls[l.controlId] : undefined;
+        const newCtrl = l.controlId ? updatedControls[l.controlId] : undefined;
+        if (oldCtrl && newCtrl) {
+          base.x = Math.round(newCtrl.x + (l.x - oldCtrl.x) * factor);
+          base.y = Math.round(newCtrl.y + (l.y - oldCtrl.y) * factor);
+        }
+
+        return base;
+      });
 
       return {
         controls: updatedControls,


### PR DESCRIPTION
## Summary

### Canvas Resize
- W/H inputs call `scaleCanvas()` — all controls, sections, labels scale proportionally
- `scaleCanvas()` now also scales `control.labelFontSize` (pad on-button text)
- Labels track their linked controls during resize (no drift between label and button)
- Null guard prevents crash when label references a deleted control

### Preview Fix
- `storeToManifest` now passes `labelFontSize` to PanelRenderer
- Preview pad labels match editor size (was defaulting to 11px)

## Test plan
- [ ] Type new W value → controls scale proportionally
- [ ] Shrink then grow back → labels maintain spacing from buttons
- [ ] Preview pad labels match editor size
- [ ] No "fewer hooks" error during resize
- [ ] Cmd+Z undoes canvas resize
- [ ] `npx vitest run` — 1028 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)