### PR TITLE
feat: lock modes, resize guard, label font size fixes

### DIFF
--- a/src/components/controls/PanelButton.tsx
+++ b/src/components/controls/PanelButton.tsx
@@ -17,6 +17,7 @@ interface PanelButtonProps {
   labelPosition?: 'on' | 'above' | 'below';
   surfaceColor?: string;
   iconContent?: string;
+  labelFontSize?: number;
   onClick?: () => void;
 }
 
@@ -96,6 +97,7 @@ export default function PanelButton({
   labelPosition = 'on',
   surfaceColor,
   iconContent,
+  labelFontSize,
   onClick,
 }: PanelButtonProps) {
   // Fluid mode: when width/height are provided, compute all visuals proportionally.
@@ -109,7 +111,7 @@ export default function PanelButton({
   const isFlatKey = variant === 'flat-key';
 
   // ── Fluid sizing computations ──────────────────────────────────────────
-  const fluidFontSize = isFluid ? Math.max(Math.round(height! * 0.35), 6) : undefined;
+  const fluidFontSize = isFluid ? (labelFontSize ?? Math.max(Math.round(height! * 0.35), 6)) : undefined;
   const fluidBorderRadius = isFluid
     ? (isTransport ? '50%' : Math.max(Math.round(Math.min(width!, height!) * 0.15), 2))
     : undefined;

--- a/src/components/controls/PanelRenderer.tsx
+++ b/src/components/controls/PanelRenderer.tsx
@@ -109,11 +109,11 @@ function renderLabelText(text: string): React.ReactNode {
 
 function inferPortVariant(label: string): string {
   const l = label.toLowerCase();
-  if (l.includes('usb')) return 'usb';
-  if (l.includes('midi')) return 'midi';
+  if (l.includes('usb')) return 'usb-a';
   if (l.includes('sd') || l.includes('card')) return 'sd-card';
-  if (l.includes('power') || l.includes('dc')) return 'power';
-  return 'audio';
+  if (l.includes('ethernet') || l.includes('lan')) return 'ethernet';
+  if (l.includes('rca') || l.includes('phono')) return 'rca';
+  return 'usb-a';
 }
 
 // ─── Control Renderer ───────────────────────────────────────────────────────
@@ -162,7 +162,7 @@ function renderControl(
             >
               {showInside && (
                 <span className="font-medium text-gray-300 uppercase text-center leading-tight px-1"
-                  style={{ fontSize: isIcon ? 14 : 8 }}>
+                  style={{ fontSize: control.labelFontSize ?? (isIcon ? 14 : 8) }}>
                   {displayText}
                 </span>
               )}
@@ -200,6 +200,7 @@ function renderControl(
             hasLed={control.hasLed && control.ledPosition === 'inside'}
             ledOn={ledOn}
             ledColor={control.ledColor ?? undefined}
+            labelFontSize={control.labelFontSize}
             onClick={onClick}
           />
         </div>

--- a/src/components/panel-editor/ContextMenu.tsx
+++ b/src/components/panel-editor/ContextMenu.tsx
@@ -112,6 +112,8 @@ export default function ContextMenu() {
   if (!control) return null;
 
   const isLocked = control.locked;
+  const isResizeLocked = control.resizeLocked;
+  const lockLabel = isLocked ? 'Unlock' : isResizeLocked ? 'Lock Fully' : 'Lock Size';
   const selectedCount = useEditorStore.getState().selectedIds.length;
 
   return createPortal(
@@ -135,8 +137,11 @@ export default function ContextMenu() {
 
         {/* Delete */}
         <button
-          className="flex w-full items-center justify-between px-3 py-1.5 hover:bg-gray-800 hover:text-red-400 transition-colors text-left"
-          onClick={handleDelete}
+          className={`flex w-full items-center justify-between px-3 py-1.5 transition-colors text-left ${
+            isLocked ? 'text-gray-600 cursor-not-allowed' : 'hover:bg-gray-800 hover:text-red-400'
+          }`}
+          onClick={isLocked ? undefined : handleDelete}
+          disabled={isLocked}
         >
           <span>Delete</span>
           <span className="text-gray-600 ml-4">Del</span>
@@ -145,12 +150,12 @@ export default function ContextMenu() {
         {/* Separator */}
         <div className="my-1 h-px bg-gray-800" />
 
-        {/* Lock / Unlock */}
+        {/* Lock cycle: Unlocked → Size Locked → Fully Locked → Unlocked */}
         <button
           className="flex w-full items-center px-3 py-1.5 hover:bg-gray-800 hover:text-white transition-colors text-left"
           onClick={handleToggleLock}
         >
-          {isLocked ? 'Unlock' : 'Lock'}
+          {lockLabel}
         </button>
 
         {/* Multi-select: Alignment & Grouping */}

--- a/src/components/panel-editor/ControlNode.tsx
+++ b/src/components/panel-editor/ControlNode.tsx
@@ -259,7 +259,7 @@ function renderControl(control: ControlDef, isSelected: boolean, allControls: Re
               {showInside && (
                 <span
                   className="font-medium text-gray-300 uppercase text-center leading-tight px-1"
-                  style={{ fontSize: isIcon ? 14 : 8 }}
+                  style={{ fontSize: control.labelFontSize ?? (isIcon ? 14 : 8) }}
                 >
                   {text}
                 </span>
@@ -294,6 +294,7 @@ function renderControl(control: ControlDef, isSelected: boolean, allControls: Re
             hasLed={control.hasLed && control.ledPosition !== 'inside'}
             ledColor={control.ledColor ?? undefined}
             labelPosition={mapButtonLabelPosition(control.labelPosition)}
+            labelFontSize={control.labelFontSize}
           />
         </div>
       );
@@ -650,6 +651,10 @@ export default function ControlNode({ controlId, sectionId }: ControlNodeProps) 
       // Rnd reports the visual size (scaled). Divide by controlScale to get the stored "full size".
       const newW = Math.round(parseInt(ref.style.width, 10) / controlScale);
       const newH = Math.round(parseInt(ref.style.height, 10) / controlScale);
+      // Ignore micro-resizes (< 3px in both dimensions) to prevent accidental resizes
+      const deltaW = Math.abs(newW - control.w);
+      const deltaH = Math.abs(newH - control.h);
+      if (deltaW < 3 && deltaH < 3) return;
       // Snapshot BEFORE mutation so undo restores the previous state
       pushSnapshot();
       // Handle position shift from top/left resize handles
@@ -779,6 +784,8 @@ export default function ControlNode({ controlId, sectionId }: ControlNodeProps) 
   if (control.nestedIn && allControls[control.nestedIn]) return null;
 
   const isLocked = control.locked;
+  const isResizeLocked = control.resizeLocked;
+  const canResize = !isLocked && !isResizeLocked;
 
   // Controls can be dragged freely — section boundaries are decorative only.
 
@@ -792,8 +799,11 @@ export default function ControlNode({ controlId, sectionId }: ControlNodeProps) 
         resizeGrid={[snapGrid, snapGrid]}
         lockAspectRatio={shiftHeld}
         disableDragging={isLocked}
-        enableResizing={!isLocked}
-        resizeHandleStyles={isSelected ? {
+        enableResizing={canResize ? {
+          topRight: true, bottomRight: true, bottomLeft: true, topLeft: true,
+          top: false, right: false, bottom: false, left: false,
+        } : false}
+        resizeHandleStyles={isSelected && canResize ? {
           bottomRight: { width: 10, height: 10, right: -5, bottom: -5, background: '#3b82f6', borderRadius: '50%', cursor: 'nwse-resize' },
           bottomLeft: { width: 10, height: 10, left: -5, bottom: -5, background: '#3b82f6', borderRadius: '50%', cursor: 'nesw-resize' },
           topRight: { width: 10, height: 10, right: -5, top: -5, background: '#3b82f6', borderRadius: '50%', cursor: 'nesw-resize' },
@@ -804,13 +814,13 @@ export default function ControlNode({ controlId, sectionId }: ControlNodeProps) 
         onResizeStop={handleResizeStop}
         style={{
           outline: isSelected
-            ? '2px solid rgba(59,130,246,0.8)'
+            ? `2px solid ${isLocked ? 'rgba(234,179,8,0.6)' : 'rgba(59,130,246,0.8)'}`
             : 'none',
           outlineOffset: 1,
           borderRadius: 2,
           zIndex: isSelected ? 50 : isGrouped ? 10 : 5,
           boxShadow: isSelected
-            ? '0 0 8px 2px rgba(59,130,246,0.3)'
+            ? isLocked ? '0 0 8px 2px rgba(234,179,8,0.2)' : '0 0 8px 2px rgba(59,130,246,0.3)'
             : 'none',
           opacity: isLocked ? 0.5 : controlScale < 1 ? (isSelected ? 1 : 0.7) : 1,
           cursor: isLocked ? 'not-allowed' : 'move',
@@ -822,13 +832,22 @@ export default function ControlNode({ controlId, sectionId }: ControlNodeProps) 
         className="control-node"
       >
         {/* Lock icon badge (top-right) */}
-        {isLocked && (
+        {(isLocked || isResizeLocked) && (
           <div
-            className="absolute -top-1 -right-1 flex h-4 w-4 items-center justify-center rounded-full bg-gray-800 text-[8px] text-yellow-400 border border-gray-600 pointer-events-none"
+            className={`absolute -top-1 -right-1 flex h-4 w-4 items-center justify-center rounded-full border pointer-events-none ${
+              isLocked
+                ? 'bg-yellow-900/80 text-yellow-400 border-yellow-600'
+                : 'bg-blue-900/80 text-blue-400 border-blue-600'
+            }`}
             style={{ zIndex: 20 }}
-            title="Locked"
+            title={isLocked ? 'Fully Locked' : 'Size Locked'}
           >
-            L
+            <svg className="h-2.5 w-2.5" viewBox="0 0 16 16" fill="currentColor">
+              <path d="M3 9a1 1 0 0 1 1-1h8a1 1 0 0 1 1 1v5a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V9z" />
+              {isLocked && (
+                <path d="M6 5a2 2 0 1 1 4 0v3H6V5z" />
+              )}
+            </svg>
           </div>
         )}
 

--- a/src/components/panel-editor/LayersPanel.tsx
+++ b/src/components/panel-editor/LayersPanel.tsx
@@ -41,6 +41,9 @@ function ControlItem({ controlId }: { controlId: string }) {
 
   if (!control) return null;
 
+  const isLocked = control.locked;
+  const isResizeLocked = control.resizeLocked;
+
   return (
     <button
       ref={itemRef}
@@ -48,10 +51,18 @@ function ControlItem({ controlId }: { controlId: string }) {
       className={`flex w-full items-center gap-1 rounded px-2 py-1 text-left text-[10px] transition-colors ${
         isSelected
           ? 'bg-blue-600/30 text-white'
-          : 'text-gray-400 hover:bg-white/5 hover:text-gray-200'
+          : isLocked
+            ? 'text-gray-500 hover:bg-white/5 hover:text-gray-300'
+            : 'text-gray-400 hover:bg-white/5 hover:text-gray-200'
       }`}
     >
-      <span className="flex-1 truncate">{truncate(control.label || control.id, 22)}</span>
+      {(isLocked || isResizeLocked) && (
+        <svg className={`h-2.5 w-2.5 flex-shrink-0 ${isLocked ? 'text-yellow-500' : 'text-blue-500'}`} viewBox="0 0 16 16" fill="currentColor">
+          <path d="M3 9a1 1 0 0 1 1-1h8a1 1 0 0 1 1 1v5a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V9z" />
+          {isLocked && <path d="M6 5a2 2 0 1 1 4 0v3H6V5z" />}
+        </svg>
+      )}
+      <span className="flex-1 truncate">{truncate(control.label || control.id, isLocked || isResizeLocked ? 18 : 22)}</span>
       <span className="flex-shrink-0 text-[8px] text-gray-600 uppercase">{control.type}</span>
     </button>
   );

--- a/src/components/panel-editor/PropertiesPanel/index.tsx
+++ b/src/components/panel-editor/PropertiesPanel/index.tsx
@@ -475,14 +475,35 @@ function SingleControlProperties({ control }: { control: ControlDef }) {
       {/* Divider */}
       <div className="h-px bg-gray-800" />
 
-      {/* Lock status */}
-      <div className="flex items-center justify-between">
-        <span className="text-[10px] uppercase tracking-wide text-gray-500">
-          Locked
-        </span>
-        <span className="text-xs text-gray-400">
-          {control.locked ? 'Yes' : 'No'}
-        </span>
+      {/* Lock mode */}
+      <div className="space-y-1">
+        <label className="text-[10px] uppercase tracking-wide text-gray-500">
+          Lock
+        </label>
+        <div className="flex gap-1">
+          {([['unlocked', 'Unlocked'], ['size-locked', 'Size'], ['fully-locked', 'Full']] as const).map(([mode, label]) => {
+            const currentMode = control.locked ? 'fully-locked' : control.resizeLocked ? 'size-locked' : 'unlocked';
+            const isActive = currentMode === mode;
+            return (
+              <button
+                key={mode}
+                onClick={() => {
+                  pushSnapshot();
+                  useEditorStore.getState().setLockMode(ids, mode);
+                }}
+                className={`flex-1 rounded px-1.5 py-1 text-[9px] font-medium transition-colors ${
+                  isActive
+                    ? mode === 'fully-locked' ? 'bg-yellow-600/30 text-yellow-300 border border-yellow-600'
+                      : mode === 'size-locked' ? 'bg-blue-600/30 text-blue-300 border border-blue-600'
+                      : 'bg-gray-600/30 text-gray-200 border border-gray-500'
+                    : 'bg-gray-800 text-gray-500 border border-gray-700 hover:text-gray-300'
+                }`}
+              >
+                {label}
+              </button>
+            );
+          })}
+        </div>
       </div>
     </div>
   );
@@ -893,6 +914,39 @@ function MultiControlProperties({ controls }: { controls: ControlDef[] }) {
           </div>
         </>
       )}
+
+      {/* ── Lock Mode ─────────────────────────────────────────────── */}
+      <div className="h-px bg-gray-800" />
+      <div className="space-y-1">
+        <label className="text-[10px] uppercase tracking-wide text-gray-500">
+          Lock
+        </label>
+        <div className="flex gap-1">
+          {([['unlocked', 'Unlocked'], ['size-locked', 'Size'], ['fully-locked', 'Full']] as const).map(([mode, label]) => {
+            const modes = controls.map(c => c.locked ? 'fully-locked' : c.resizeLocked ? 'size-locked' : 'unlocked');
+            const isActive = modes.every(m => m === mode);
+            const isMixed = !allSame(modes);
+            return (
+              <button
+                key={mode}
+                onClick={() => {
+                  pushSnapshot();
+                  useEditorStore.getState().setLockMode(ids, mode);
+                }}
+                className={`flex-1 rounded px-1.5 py-1 text-[9px] font-medium transition-colors ${
+                  isActive
+                    ? mode === 'fully-locked' ? 'bg-yellow-600/30 text-yellow-300 border border-yellow-600'
+                      : mode === 'size-locked' ? 'bg-blue-600/30 text-blue-300 border border-blue-600'
+                      : 'bg-gray-600/30 text-gray-200 border border-gray-500'
+                    : 'bg-gray-800 text-gray-500 border border-gray-700 hover:text-gray-300'
+                }`}
+              >
+                {label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
 
       {/* ── Group / Ungroup ────────────────────────────────────────── */}
       {controls.length >= 2 && (

--- a/src/components/panel-editor/store/manifestSlice.ts
+++ b/src/components/panel-editor/store/manifestSlice.ts
@@ -79,6 +79,7 @@ export interface ControlDef {
   sectionId: string;
   labelPosition: 'above' | 'below' | 'left' | 'right' | 'on-button' | 'hidden';
   locked: boolean;
+  resizeLocked?: boolean; // Size locked — can move but can't resize
   rotation?: number; // 0, 90, 180, 270 degrees
   secondaryLabel?: string;
   spatialNeighbors?: {
@@ -198,6 +199,7 @@ export interface ManifestSlice {
   duplicateSelected: () => void;
   deleteSelected: () => void;
   toggleLock: (id: string) => void;
+  setLockMode: (ids: string[], mode: 'unlocked' | 'size-locked' | 'fully-locked') => void;
   setSelectedIds: (ids: string[]) => void;
   toggleSelected: (id: string) => void;
   setFocusedSection: (id: string | null) => void;
@@ -845,7 +847,7 @@ export const createManifestSlice: StateCreator<
 
   resizeControl: (id, w, h) => {
     const ctrl = get().controls[id];
-    if (!ctrl || ctrl.locked) return;
+    if (!ctrl || ctrl.locked || ctrl.resizeLocked) return;
     set((s) => ({
       controls: {
         ...s.controls,
@@ -968,7 +970,18 @@ export const createManifestSlice: StateCreator<
         controls[id] = { ...ctrl, [field]: value };
       }
     }
-    set({ controls });
+    // Sync labelFontSize → linked editorLabel.fontSize
+    if (field === 'labelFontSize') {
+      const idSet = new Set(ids);
+      const updatedLabels = (get().editorLabels as EditorLabel[]).map((l) =>
+        l.controlId && idSet.has(l.controlId)
+          ? { ...l, fontSize: value as number }
+          : l,
+      );
+      set({ controls, editorLabels: updatedLabels });
+    } else {
+      set({ controls });
+    }
   },
 
   duplicateSelected: () => {
@@ -1015,11 +1028,15 @@ export const createManifestSlice: StateCreator<
     const { selectedIds, controls, sections } = get();
     if (selectedIds.length === 0) return;
 
-    const deleteSet = new Set(selectedIds);
+    // Skip fully locked controls — they can't be deleted
+    const deletable = selectedIds.filter(id => !controls[id]?.locked);
+    if (deletable.length === 0) return;
+
+    const deleteSet = new Set(deletable);
     const updatedControls = { ...controls };
     const updatedSections = { ...sections };
 
-    for (const id of selectedIds) {
+    for (const id of deletable) {
       const ctrl = updatedControls[id];
       if (!ctrl) continue;
 
@@ -1060,19 +1077,55 @@ export const createManifestSlice: StateCreator<
 
   toggleLock: (id) => {
     const { lockedIds, controls } = get();
-    const isLocked = lockedIds.includes(id);
     const ctrl = controls[id];
     if (!ctrl) return;
 
-    set({
-      lockedIds: isLocked
-        ? lockedIds.filter((lid) => lid !== id)
-        : [...lockedIds, id],
-      controls: {
-        ...controls,
-        [id]: { ...ctrl, locked: !isLocked },
-      },
-    });
+    // Cycle: unlocked → size-locked → fully-locked → unlocked
+    if (!ctrl.locked && !ctrl.resizeLocked) {
+      // Unlocked → Size Locked
+      set({
+        controls: { ...controls, [id]: { ...ctrl, resizeLocked: true } },
+      });
+    } else if (ctrl.resizeLocked && !ctrl.locked) {
+      // Size Locked → Fully Locked
+      set({
+        lockedIds: [...lockedIds.filter(lid => lid !== id), id],
+        controls: { ...controls, [id]: { ...ctrl, locked: true, resizeLocked: false } },
+      });
+    } else {
+      // Fully Locked → Unlocked
+      set({
+        lockedIds: lockedIds.filter((lid) => lid !== id),
+        controls: { ...controls, [id]: { ...ctrl, locked: false, resizeLocked: false } },
+      });
+    }
+  },
+
+  setLockMode: (ids, mode) => {
+    const { controls, lockedIds } = get();
+    const updated = { ...controls };
+    let newLockedIds = [...lockedIds];
+
+    for (const id of ids) {
+      const ctrl = updated[id];
+      if (!ctrl) continue;
+      switch (mode) {
+        case 'unlocked':
+          updated[id] = { ...ctrl, locked: false, resizeLocked: false };
+          newLockedIds = newLockedIds.filter(lid => lid !== id);
+          break;
+        case 'size-locked':
+          updated[id] = { ...ctrl, locked: false, resizeLocked: true };
+          newLockedIds = newLockedIds.filter(lid => lid !== id);
+          break;
+        case 'fully-locked':
+          updated[id] = { ...ctrl, locked: true, resizeLocked: false };
+          if (!newLockedIds.includes(id)) newLockedIds.push(id);
+          break;
+      }
+    }
+
+    set({ controls: updated, lockedIds: newLockedIds });
   },
 
   setSelectedIds: (ids) => set({ selectedIds: ids, selectedLabelId: ids.length > 0 ? null : get().selectedLabelId }),


### PR DESCRIPTION
## Summary
- **Lock modes**: 3-mode locking system (Unlocked / Size Locked / Fully Locked) with pill selector in Properties panel, cycling context menu, and lock icons in Layers panel
- **3px resize guard**: Prevents accidental micro-resizes from misclicks
- **CDJ-3000 preview fix**: `inferPortVariant` was returning variants not in Port's lookup (`'usb'` instead of `'usb-a'`), crashing the preview
- **Label font size slider**: Now works for all label positions — syncs `control.labelFontSize` to `editorLabel.fontSize`, wires `labelFontSize` prop through PanelButton and circle buttons

## Test plan
- [ ] Select control → Properties panel shows Lock pills (Unlocked/Size/Full)
- [ ] Set Size Locked → can drag but no resize handles appear
- [ ] Set Fully Locked → can't drag or resize, yellow outline + lock badge
- [ ] Right-click cycles: Lock Size → Lock Fully → Unlock
- [ ] Delete key skips fully locked controls
- [ ] Layers panel shows lock icon next to locked/size-locked controls
- [ ] CDJ-3000 preview button no longer crashes
- [ ] Label font size slider works for above/below/left/right positions
- [ ] Label font size slider works for on-button (rect buttons, circle buttons, pads)

🤖 Generated with [Claude Code](https://claude.com/claude-code)